### PR TITLE
MIDI: support virtual wires/plug

### DIFF
--- a/src/Adafruit_USBD_MIDI.h
+++ b/src/Adafruit_USBD_MIDI.h
@@ -31,6 +31,7 @@ class Adafruit_USBD_MIDI : public Stream, Adafruit_USBD_Interface
 {
   public:
     Adafruit_USBD_MIDI(void);
+    Adafruit_USBD_MIDI(uint8_t n_cables);
 
     bool begin(void);
 
@@ -44,8 +45,11 @@ class Adafruit_USBD_MIDI : public Stream, Adafruit_USBD_Interface
     virtual int    peek       ( void );
     virtual void   flush      ( void );
 
-    // fron Adafruit_USBD_Interface
+    // from Adafruit_USBD_Interface
     virtual uint16_t getDescriptor(uint8_t itfnum, uint8_t* buf, uint16_t bufsize);
+
+  private:
+    uint8_t _n_cables;
 };
 
 #endif /* ADAFRUIT_USBD_MIDI_H_ */


### PR DESCRIPTION
Allow to specify the number of virtual wires/plugs to be created for
the MIDI interface.

Initializing the MIDI device with:
  Adafruit_USBD_MIDI usb_midi(3);

xports a single device with three separate ports/jacks/wires.
The ID (4 bit) of the jack/port is carried in the header packet of
the USB MIDI wire message.

--
This change requires the following change to the tinyusb core:
 https://github.com/adafruit/ArduinoCore-samd/pull/179