### PR TITLE
MIDI: Add raw USB packet interface

### DIFF
--- a/examples/MIDI/midi_virtual_ports/MIDI.cpp
+++ b/examples/MIDI/midi_virtual_ports/MIDI.cpp
@@ -1,0 +1,63 @@
+#include "MIDI.h"
+
+MIDIPacket::MIDIPacket() {}
+
+MIDIPacket::MIDIPacket(uint8_t port) :
+  _port(port) {}
+
+uint8_t MIDIPacket::getPort() {
+  return (_data[0] >> 4);
+}
+
+void MIDIPacket::setPort(uint8_t port) {
+  _port = port;
+}
+
+uint8_t MIDIPacket::getChannel() {
+  return (_data[1] & 0x0f);
+}
+
+MIDIPacket::PacketType MIDIPacket::getType() {
+    return static_cast<PacketType>((_data[1] >> 4) & 0x07);
+}
+
+uint8_t MIDIPacket::getNote() {
+  return _data[2];
+}
+
+uint8_t MIDIPacket::getNoteVelocity() {
+  return _data[3];
+}
+
+const MIDIPacket* MIDIPacket::set(uint8_t channel, PacketType type, uint8_t data1, uint8_t data2) {
+  _data[0] = (_port << 4) | (0x08 | type);
+  _data[1] = 0x80 | (type << 4) | channel;
+  _data[2] = data1;
+  _data[3] = data2;
+  return this;
+}
+
+const MIDIPacket* MIDIPacket::setNote(uint8_t channel, uint8_t note, uint8_t velocity) {
+  if (velocity == 0)
+    return set(channel, NoteOff, note, 64);
+
+  return set(channel, NoteOn, note, velocity);
+}
+
+MIDI::MIDI() :
+  _device() {}
+
+MIDI::MIDI(uint8_t n_ports) :
+  _device(n_ports) {}
+
+void MIDI::begin() {
+  _device.begin();
+}
+
+bool MIDI::send(const MIDIPacket* packet) {
+  return _device.send(packet->_data);
+}
+
+bool MIDI::receive(MIDIPacket* packet) {
+  return _device.receive(packet->_data);
+}

--- a/examples/MIDI/midi_virtual_ports/MIDI.h
+++ b/examples/MIDI/midi_virtual_ports/MIDI.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <Adafruit_TinyUSB.h>
+
+// The USB MIDI packet
+// Every packet is 4 bytes long, only the status byte has the 7th bit set:
+//   1. header (4 bits virtual port/wire number + 4th bit is set + 3 bits type)
+//   2. status (7th bit is set, 3 bits type + 4 bits channel/system number)
+//   3. data byte 1 (7 bit)
+//   4. data byte 2 (7 bit)
+class MIDIPacket {
+  public:
+    // 3 bits type
+    enum PacketType {
+      NoteOff =           0,
+      NoteOn =            1,
+      Aftertouch =        2,
+      ControlChange =     3,
+      ProgramChange =     4,
+      AftertouchChannel = 5,
+      PitchBend =         6,
+      System =            7
+    };
+
+    MIDIPacket();
+
+    // Set virtual port/wire in the packet. Port 1 == 0
+    MIDIPacket(uint8_t port);
+    uint8_t getPort();
+    void setPort(uint8_t port);
+
+    // Channel 1 == 0
+    uint8_t getChannel();
+
+    PacketType getType();
+
+    uint8_t getNote();
+    uint8_t getNoteVelocity();
+
+    // Encode values into the packet and return a pointer to it. The result
+    // can be passed to the send() method.
+    // Example which sends out a Middle-C note at channel 1 with velocity 80:
+    //   #include <MIDI.h>
+    //   static MIDI MIDI;
+    //   static MIDIPacket midi;
+    //   MIDI.begin();
+    //   MIDI.send(midi.setNote(0, 60, 80));
+    const MIDIPacket* set(uint8_t channel, PacketType type, uint8_t data1, uint8_t data2);
+    const MIDIPacket* setNote(uint8_t channel, uint8_t note, uint8_t velocity);
+
+  private:
+    friend class MIDI;
+    uint8_t _port;
+    uint8_t _data[4];
+};
+
+// The USB MIDI device
+class MIDI {
+  public:
+    MIDI();
+    MIDI(uint8_t n_ports);
+    void begin();
+    bool send(const MIDIPacket* packet);
+    bool receive(MIDIPacket* packet);
+
+  private:
+    Adafruit_USBD_MIDI _device;
+};

--- a/examples/MIDI/midi_virtual_ports/midi_virtual_ports.ino
+++ b/examples/MIDI/midi_virtual_ports/midi_virtual_ports.ino
@@ -1,0 +1,98 @@
+/* This sketch is enumerated as USB MIDI device which shows up at the
+   host as a single MIDI interface with 3 virtual ports/wires.
+
+    Every port continuously sends out notes:
+      port 1, channel 1: monochord (single tone)
+      port 2, channel 4: dichord (two tones)
+      port 3, channel 8: trichord (three tones)
+
+    Notes received on the ports let the built-in LED blink one, two,
+    or three times.
+
+    MIDI.h is a small wrapper around the USB MIDI packet interface
+    provided by Adafruit_USBD_MIDI device.
+*/
+
+#include "MIDI.h"
+
+// MIDI interface with 3 virtual ports/wires
+static MIDI MIDI(3);
+
+void setup() {
+  Serial.begin(9600);
+  MIDI.begin();
+}
+
+static unsigned long loop_millis;
+static uint8_t loop_position;
+
+void loop() {
+  // Received MIDI packet
+  static MIDIPacket in;
+
+  // Receive packet and let the LED blink as many times as
+  // the port number
+  if (MIDI.receive(&in)) {
+    Serial.print("Received: Port=");
+    Serial.print(in.getPort() + 1);
+    Serial.print(" Channel=");
+    Serial.print(in.getChannel() + 1);
+    Serial.print(" Type=");
+    Serial.print(in.getType());
+    Serial.print(" Note=");
+    Serial.print(in.getNote());
+    Serial.print(" Value=");
+    Serial.println(in.getNoteVelocity());
+    if (in.getType() == MIDIPacket::NoteOn) {
+      for (uint8_t i = 0; i < in.getPort() + 1; i++) {
+        digitalWrite(LED_BUILTIN, HIGH);
+        delay(75);
+        digitalWrite(LED_BUILTIN, LOW);
+        delay(75);
+      }
+    }
+  }
+
+  // Packets to send out at a defined port
+  static MIDIPacket out1(0);
+  static MIDIPacket out2(1);
+  static MIDIPacket out3(2);
+
+  // Send as many notes as the port number, once every 4 seconds
+  if ((unsigned long)(millis() - loop_millis) > 1000) {
+    switch (loop_position) {
+      case 0:
+        // One note (C) on all ports
+        MIDI.send(out1.setNote(0, 60, 64));
+        MIDI.send(out2.setNote(3, 60, 64));
+        MIDI.send(out3.setNote(7, 60, 64));
+        break;
+
+      case 1:
+        // Second note (E) on port 2 and 3
+        MIDI.send(out2.setNote(3, 64, 64));
+        MIDI.send(out3.setNote(7, 64, 64));
+        break;
+
+      case 2:
+        // Third note (G) on port3
+        MIDI.send(out3.setNote(7, 67, 64));
+        break;
+
+      case 3:
+        // All notes off
+        MIDI.send(out1.setNote(0, 60, 0));
+        MIDI.send(out2.setNote(3, 60, 0));
+        MIDI.send(out3.setNote(7, 60, 0));
+        MIDI.send(out2.setNote(3, 64, 0));
+        MIDI.send(out3.setNote(7, 64, 0));
+        MIDI.send(out3.setNote(7, 67, 0));
+    }
+
+    loop_position++;
+    if (loop_position == 4)
+      loop_position = 0;
+
+    loop_millis = millis();
+  }
+}

--- a/src/Adafruit_USBD_MIDI.cpp
+++ b/src/Adafruit_USBD_MIDI.cpp
@@ -125,5 +125,14 @@ void Adafruit_USBD_MIDI::flush (void)
   // MIDI Library doen't use flush
 }
 
-#endif
+bool Adafruit_USBD_MIDI::send(const uint8_t packet[4])
+{
+  return tud_midi_send(packet);
+}
 
+bool Adafruit_USBD_MIDI::receive(uint8_t packet[4])
+{
+  return tud_midi_receive(packet);
+}
+
+#endif

--- a/src/Adafruit_USBD_MIDI.h
+++ b/src/Adafruit_USBD_MIDI.h
@@ -31,19 +31,25 @@ class Adafruit_USBD_MIDI : public Stream, Adafruit_USBD_Interface
 {
   public:
     Adafruit_USBD_MIDI(void);
+
+    // MIDI USB virtual cables/plugs/wires.
     Adafruit_USBD_MIDI(uint8_t n_cables);
 
     bool begin(void);
 
-    // for MIDI library
-    bool begin(uint32_t baud) { (void) baud; return begin(); }
-
-    // Stream interface to use with MIDI Library
+    // Stream interface to use with MIDI Library. USB MIDI packets
+    // are translated into a byte stream with variable size messages,
+    // similar to the MIDI serial connection format.
+    bool begin(uint32_t baud) { return begin(); }
     virtual int    read       ( void );
     virtual size_t write      ( uint8_t b );
     virtual int    available  ( void );
     virtual int    peek       ( void );
     virtual void   flush      ( void );
+
+    // Raw MIDI USB packet interface.
+    bool send(const uint8_t packet[4]);
+    bool receive(uint8_t packet[4]);
 
     // from Adafruit_USBD_Interface
     virtual uint16_t getDescriptor(uint8_t itfnum, uint8_t* buf, uint16_t bufsize);


### PR DESCRIPTION
Add methods to send and retrieve a full 4-byte USB MIDI packet:
  bool send(const MIDIPacket* packet);
  bool receive(MIDIPacket* packet);

Add example 'midi_virtual_ports.ino':
  The sketch is enumerated as USB MIDI device which shows up at the
  host as a single MIDI interface with 3 virtual ports/wires.

  Every port continuously sends out notes:
    Port 1, channel 1: monochord (single tone)
    port 2, channel 4: dichord (two tones)
    port 3, channel 8: trichord (three tones)

  Notes received on the ports let the built-in LED blink one, two,
  or three times.

  MIDI.h is a small wrapper around the USB MIDI packet interface. It
  does not require any external MIDI library.