### PR TITLE
allow use of all write() variants

### DIFF
--- a/src/Adafruit_USBD_MIDI.h
+++ b/src/Adafruit_USBD_MIDI.h
@@ -46,6 +46,8 @@ public:
   virtual int peek(void);
   virtual void flush(void);
 
+  using Stream::write;
+
   // Raw MIDI USB packet interface.
   bool send(const uint8_t packet[4]);
   bool receive(uint8_t packet[4]);


### PR DESCRIPTION
Adafruit_USBD_MIDI implements Stream, and transitively Print. 

Print overloads write() with several versions, only one of which must be implemented, write(uint8_t).

Because Adafruit_USBD_MIDI declares write(uint8_t) in its class definition (as it must), it will _lose_ the overloaded versions, unless explicitly including them with a using declaration... Which is what this commit does.

Without this using declaration, users of this class cannot call write(const char* str) or write(const uint8_t *, size_t) as they would expect, since it inherits from Print.