### PR TITLE
Use only unsigned value for array access

### DIFF
--- a/src/Adafruit_USBD_HID.cpp
+++ b/src/Adafruit_USBD_HID.cpp
@@ -177,7 +177,7 @@ bool Adafruit_USBD_HID::keyboardReport(uint8_t report_id, uint8_t modifier,
 bool Adafruit_USBD_HID::keyboardPress(uint8_t report_id, char ch) {
   uint8_t keycode[6] = {0};
   uint8_t modifier = 0;
-  uint8_t uch = (uint8_t)ch; // ensure no negative values used as index into array
+  uint8_t uch = (uint8_t)ch;
 
   if (_ascii2keycode[uch][0])
     modifier = KEYBOARD_MODIFIER_LEFTSHIFT;

--- a/src/Adafruit_USBD_HID.cpp
+++ b/src/Adafruit_USBD_HID.cpp
@@ -177,10 +177,11 @@ bool Adafruit_USBD_HID::keyboardReport(uint8_t report_id, uint8_t modifier,
 bool Adafruit_USBD_HID::keyboardPress(uint8_t report_id, char ch) {
   uint8_t keycode[6] = {0};
   uint8_t modifier = 0;
+  uint8_t uch = (uint8_t)ch; // ensure no negative values used as index into array
 
-  if (_ascii2keycode[ch][0])
+  if (_ascii2keycode[uch][0])
     modifier = KEYBOARD_MODIFIER_LEFTSHIFT;
-  keycode[0] = _ascii2keycode[ch][1];
+  keycode[0] = _ascii2keycode[uch][1];
 
   return tud_hid_keyboard_report(report_id, modifier, keycode);
 }


### PR DESCRIPTION
GCC catches this bug.

```
...\libraries\Adafruit_TinyUSB_Library\src\Adafruit_USBD_HID.cpp:
      Line 181 Char 22
      In member function 'bool Adafruit_USBD_HID::keyboardPress(uint8_t, char)':
      warning: array subscript has type 'char' [-Wchar-subscripts]
  181 |   if (_ascii2keycode[ch][0])
      |                      ^~
...\libraries\Adafruit_TinyUSB_Library\src\Adafruit_USBD_HID.cpp:
      Line 183 Char 31
      warning: array subscript has type 'char' [-Wchar-subscripts]
  183 |   keycode[0] = _ascii2keycode[ch][1];
      |                               ^~
```