### PR TITLE
warn menu selection for port that has TinyUSB as optional menu

### DIFF
--- a/src/Adafruit_TinyUSB.h
+++ b/src/Adafruit_TinyUSB.h
@@ -25,11 +25,12 @@
 #ifndef ADAFRUIT_TINYUSB_H_
 #define ADAFRUIT_TINYUSB_H_
 
-#include "tusb_option.h"
+// Give warning for Core that must select TinyUSB via menu
+#if (defined ARDUINO_ARCH_SAMD || defined ARDUINO_ARCH_RP2040) && !defined USE_TINYUSB
+#error TinyUSB is not selected, please select it in Tools->Menu->USB Stack
+#endif
 
-//#ifndef USE_TINYUSB
-//#error TinyUSB is not selected, please select it in Tools->Menu->USB Stack
-//#endif
+#include "tusb_option.h"
 
 #if TUSB_OPT_DEVICE_ENABLED
 

--- a/src/arduino/ports/Adafruit_TinyUSB_rp2040.cpp
+++ b/src/arduino/ports/Adafruit_TinyUSB_rp2040.cpp
@@ -24,7 +24,7 @@
 
 #include "tusb_option.h"
 
-#if defined ARDUINO_ARCH_RP2040 & TUSB_OPT_DEVICE_ENABLED
+#if defined ARDUINO_ARCH_RP2040 && TUSB_OPT_DEVICE_ENABLED
 
 #include "Arduino.h"
 #include "pico/bootrom.h"

--- a/src/arduino/ports/Adafruit_TinyUSB_samd.cpp
+++ b/src/arduino/ports/Adafruit_TinyUSB_samd.cpp
@@ -24,7 +24,7 @@
 
 #include "tusb_option.h"
 
-#if defined ARDUINO_ARCH_SAMD & TUSB_OPT_DEVICE_ENABLED
+#if defined ARDUINO_ARCH_SAMD && TUSB_OPT_DEVICE_ENABLED
 
 #include "Arduino.h"
 #include <Reset.h> // Needed for auto-reset with 1200bps port touch


### PR DESCRIPTION
warn menu selection for port that has TinyUSB as optional menu specifically samd and rp2040