### PR TITLE
Fix "-Wall -Wextra -Werror" warnings in examples

### DIFF
--- a/examples/Composite/hid_generic_inout_ramdisk/hid_generic_inout_ramdisk.ino
+++ b/examples/Composite/hid_generic_inout_ramdisk/hid_generic_inout_ramdisk.ino
@@ -86,6 +86,10 @@ void loop()
 uint16_t get_report_callback (uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
 {
   // not used in this example
+  (void) report_id;
+  (void) report_type;
+  (void) buffer;
+  (void) reqlen;
   return 0;
 }
 

--- a/examples/HID/hid_generic_inout/hid_generic_inout.ino
+++ b/examples/HID/hid_generic_inout/hid_generic_inout.ino
@@ -68,6 +68,10 @@ void loop()
 uint16_t get_report_callback (uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen)
 {
   // not used in this example
+  (void) report_id;
+  (void) report_type;
+  (void) buffer;
+  (void) reqlen;
   return 0;
 }
 

--- a/examples/HID/hid_keyboard/hid_keyboard.ino
+++ b/examples/HID/hid_keyboard/hid_keyboard.ino
@@ -13,6 +13,7 @@
 
 /* This sketch demonstrates USB HID keyboard.
  * - PIN A0-A5 is used to send digit '0' to '5' respectively
+ *   (On the RP2040, pins D0-D5 used)
  * - LED will be used as Caplock indicator
  */
 
@@ -27,7 +28,11 @@ Adafruit_USBD_HID usb_hid;
 
 // Array of pins and its keycode
 // For keycode definition see BLEHidGeneric.h
+#ifdef ARDUINO_ARCH_RP2040
+uint8_t pins[]    = { D0, D1, D2, D3, D4, D5 };
+#else
 uint8_t pins[]    = { A0, A1, A2, A3, A4, A5 };
+#endif
 uint8_t hidcode[] = { HID_KEY_0, HID_KEY_1, HID_KEY_2, HID_KEY_3 , HID_KEY_4, HID_KEY_5 };
 
 uint8_t pincount = sizeof(pins)/sizeof(pins[0]);
@@ -122,6 +127,8 @@ void loop()
 // Output report callback for LED indicator such as Caplocks
 void hid_report_callback(uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize)
 {
+  (void) report_id;
+  (void) bufsize;
   // LED indicator is output report with only 1 byte length
   if ( report_type != HID_REPORT_TYPE_OUTPUT ) return;
 


### PR DESCRIPTION
Sorry for the piecemeal PRs!  I first got CI running with the library itself and only just was able to add in the examples.