### PR TITLE
Support rp2040 mbed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 [![Build Status](https://github.com/adafruit/Adafruit_TinyUSB_Arduino/workflows/Build/badge.svg)](https://github.com/adafruit/Adafruit_TinyUSB_Arduino/actions) [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
 
-This library is a Arduino-friendly version of [TinyUSB](https://github.com/hathach/tinyusb) stack. It is designed with structure and APIs that are easily integrated to existing or new Arduino Core. Supported platform including: 
+This library is a Arduino-friendly version of [TinyUSB](https://github.com/hathach/tinyusb) stack.
+It is designed with structure and APIs that are easily integrated to an Arduino Core.
 
-- [Adafruit_nRF52_Arduino](https://github.com/adafruit/Adafruit_nRF52_Arduino)
-- [Adafruit/ArduinoCore-samd](https://github.com/adafruit/ArduinoCore-samd) selectable via menu`Tools->USB Stack->TinyUSB`
-- [earlephilhower/arduino-pico](https://github.com/earlephilhower/arduino-pico) selectable via menu `Tools->USB Stack->Adafruit TinyUSB`
+## Features
 
-Current class drivers supported are
+Currently only support device mode only, supported class drivers are:
 
 - Communication (CDC): which is used to implement `Serial` monitor
 - Human Interface Device (HID): Generic (In & Out), Keyboard, Mouse, Gamepad etc ...
@@ -16,7 +15,30 @@ Current class drivers supported are
 - Musical Instrument Digital Interface (MIDI)
 - WebUSB with vendor specific class
 
-For supported ArduinoCore, to use this library, you only need to have `<Adafruit_TinyUSB.h>` in your sketch. If your ArduinoCore does not support TinyUSB library yet, it is rather simple to port.
+## Supported Cores
+
+There are 2 type of supported cores: with and without built-in support for TinyUSB. Built-in support provide seamless integration but requires extra code added to core's source code. Unfortunately it is not always easy or possible to make those modification.
+
+### Cores with built-in support
+
+Following core has Tinyusb as either the primary usb stack or selectable via menu `Tools->USB Stack`. You only need to include `<Adafruit_TinyUSB.h>` in your sketch to use.
+
+- [Adafruit_nRF52_Arduino](https://github.com/adafruit/Adafruit_nRF52_Arduino)
+- [adafruit/ArduinoCore-samd](https://github.com/adafruit/ArduinoCore-samd)
+- [earlephilhower/arduino-pico](https://github.com/earlephilhower/arduino-pico)
+
+### Cores without built-in support
+
+Following is cores without built-in support
+
+- **mbed_rp2040**
+
+It is still possible to use TinyUSB but with some limits such as:
+
+- `TinyUSB_Device_Init()` need to be manually called in setup()
+- `TinyUSB_Device_Task()` and/or `TinyUSB_Device_FlushCDC()` may (or not) need to be manually called in loop()
+- Use `SerialTinyUSB` name instead of Serial for serial monitor
+- And there could be more other issues, using on these cores should be considered as experimental
 
 ## Class Driver API
 
@@ -24,9 +46,11 @@ More document to write ...
 
 ## Porting Guide
 
-It is rather easy if you want to integrate TinyUSB lib to your ArduinoCore.
+To integrate TinyUSB library to a Arduino core, you will need to make changes to the core for built-in support and library for porting the mcu/platform.
 
-### ArduinoCore Changes
+### Arduino Core Changes
+
+If possible, making changes to core will allow it to have built-in which make it almost transparent to user sketch 
 
 1. Add this repo as submodule (or have local copy) at your ArduioCore/libraries/Adafruit_TinyUSB_Arduino (much like SPI).
 2. Since Serial as CDC is considered as part of the core, we need to have `#include "Adafruit_USBD_CDC.h"` within your `Arduino.h`. For this to work, your `platform.txt` include path need to have `"-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"`.

--- a/examples/Composite/hid_generic_inout_ramdisk/hid_generic_inout_ramdisk.ino
+++ b/examples/Composite/hid_generic_inout_ramdisk/hid_generic_inout_ramdisk.ino
@@ -68,9 +68,9 @@ void setup()
   usb_hid.begin();
 
   Serial.begin(115200);
-  Serial.println("Waiting for USBDevice mount");
+  Serial.println("Waiting for TinyUSBDevice mount");
   // wait until device mounted
-  while( !USBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
 
   Serial.println("Adafruit TinyUSB HID Generic In Out example");
 }

--- a/examples/Composite/mouse_external_flash/mouse_external_flash.ino
+++ b/examples/Composite/mouse_external_flash/mouse_external_flash.ino
@@ -114,7 +114,7 @@ void loop()
   uint32_t const btn = (digitalRead(pin) == activeState);
 
   // Remote wakeup
-  if ( USBDevice.suspended() && btn )
+  if ( TinyUSBDevice.suspended() && btn )
   {
     // Wake up host if we are in suspend mode
     // and REMOTE_WAKEUP feature is enabled by host

--- a/examples/Composite/mouse_ramdisk/mouse_ramdisk.ino
+++ b/examples/Composite/mouse_ramdisk/mouse_ramdisk.ino
@@ -45,6 +45,11 @@ Adafruit_USBD_MSC usb_msc;
 // the setup function runs once when you press reset or power the board
 void setup()
 {
+#if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
+  // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
+  TinyUSBDevice.begin(0);
+#endif
+
   // Set disk vendor id, product id and revision with string up to 8, 16, 4 characters respectively
   usb_msc.setID("Adafruit", "Mass Storage", "1.0");
   

--- a/examples/Composite/mouse_ramdisk/mouse_ramdisk.ino
+++ b/examples/Composite/mouse_ramdisk/mouse_ramdisk.ino
@@ -47,7 +47,7 @@ void setup()
 {
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
   // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
-  TinyUSBDevice.begin(0);
+  TinyUSB_Device_Init(0);
 #endif
 
   // Set disk vendor id, product id and revision with string up to 8, 16, 4 characters respectively

--- a/examples/Composite/mouse_ramdisk/mouse_ramdisk.ino
+++ b/examples/Composite/mouse_ramdisk/mouse_ramdisk.ino
@@ -66,7 +66,7 @@ void setup()
   usb_hid.begin();
 
   Serial.begin(115200);
-  while( !USBDevice.mounted() ) delay(1);   // wait for native usb
+  while( !TinyUSBDevice.mounted() ) delay(1);   // wait for native usb
 
   Serial.println("Adafruit TinyUSB Mouse + Mass Storage (ramdisk) example");
 }
@@ -80,7 +80,7 @@ void loop()
   uint32_t const btn = (digitalRead(pin) == activeState);
 
   // Remote wakeup
-  if ( USBDevice.suspended() && btn )
+  if ( TinyUSBDevice.suspended() && btn )
   {
     // Wake up host if we are in suspend mode
     // and REMOTE_WAKEUP feature is enabled by host

--- a/examples/HID/hid_composite/hid_composite.ino
+++ b/examples/HID/hid_composite/hid_composite.ino
@@ -66,7 +66,7 @@ void setup()
   Serial.println("Adafruit TinyUSB HID Composite example");
 
   // wait until device mounted
-  while( !USBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
 }
 
 void loop()
@@ -78,11 +78,11 @@ void loop()
   bool btn_pressed = (digitalRead(pin) == activeState);
 
   // Remote wakeup
-  if ( USBDevice.suspended() && btn_pressed )
+  if ( TinyUSBDevice.suspended() && btn_pressed )
   {
     // Wake up host if we are in suspend mode
     // and REMOTE_WAKEUP feature is enabled by host
-    USBDevice.remoteWakeup();
+    TinyUSBDevice.remoteWakeup();
   }
 
   /*------------- Mouse -------------*/

--- a/examples/HID/hid_composite_joy_featherwing/hid_composite_joy_featherwing.ino
+++ b/examples/HID/hid_composite_joy_featherwing/hid_composite_joy_featherwing.ino
@@ -77,7 +77,7 @@ void setup()
   last_x = ss.analogRead(3);
 
   // wait until device mounted
-  while( !USBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
 }
 
 void loop()
@@ -145,10 +145,10 @@ void loop()
 
   /*------------- Remote Wakeup -------------*/
   // Remote wakeup if PC is suspended and we has user interaction with joy feather wing
-  if ( has_action && USBDevice.suspended() )
+  if ( has_action && TinyUSBDevice.suspended() )
   {
     // Wake up only works if REMOTE_WAKEUP feature is enable by host
     // Usually this is the case with Mouse/Keyboard device
-    USBDevice.remoteWakeup();
+    TinyUSBDevice.remoteWakeup();
   }
 }

--- a/examples/HID/hid_gamepad/hid_gamepad.ino
+++ b/examples/HID/hid_gamepad/hid_gamepad.ino
@@ -38,7 +38,7 @@ void setup()
 {
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
   // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
-  TinyUSBDevice.begin(0);
+  TinyUSB_Device_Init(0);
 #endif
 
   Serial.begin(115200);

--- a/examples/HID/hid_gamepad/hid_gamepad.ino
+++ b/examples/HID/hid_gamepad/hid_gamepad.ino
@@ -44,7 +44,7 @@ void setup()
   usb_hid.begin();
 
   // wait until device mounted
-  while( !USBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
   
   Serial.println("Adafruit TinyUSB HID Gamepad example");
 }
@@ -52,11 +52,11 @@ void setup()
 void loop() 
 { 
 //  // Remote wakeup
-//  if ( USBDevice.suspended() && btn )
+//  if ( TinyUSBDevice.suspended() && btn )
 //  {
 //    // Wake up host if we are in suspend mode
 //    // and REMOTE_WAKEUP feature is enabled by host
-//    USBDevice.remoteWakeup();
+//    TinyUSBDevice.remoteWakeup();
 //  }
 
   if ( !usb_hid.ready() ) return;

--- a/examples/HID/hid_gamepad/hid_gamepad.ino
+++ b/examples/HID/hid_gamepad/hid_gamepad.ino
@@ -36,6 +36,11 @@ hid_gamepad_report_t    gp;     // defined in hid.h from Adafruit_TinyUSB_Arduin
 
 void setup() 
 {
+#if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
+  // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
+  TinyUSBDevice.begin(0);
+#endif
+
   Serial.begin(115200);
   
   usb_hid.setPollInterval(2);

--- a/examples/HID/hid_generic_inout/hid_generic_inout.ino
+++ b/examples/HID/hid_generic_inout/hid_generic_inout.ino
@@ -41,6 +41,11 @@ Adafruit_USBD_HID usb_hid;
 // the setup function runs once when you press reset or power the board
 void setup()
 {
+#if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
+  // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
+  TinyUSBDevice.begin(0);
+#endif
+
   usb_hid.enableOutEndpoint(true);
   usb_hid.setPollInterval(2);
   usb_hid.setReportDescriptor(desc_hid_report, sizeof(desc_hid_report));

--- a/examples/HID/hid_generic_inout/hid_generic_inout.ino
+++ b/examples/HID/hid_generic_inout/hid_generic_inout.ino
@@ -43,7 +43,7 @@ void setup()
 {
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
   // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
-  TinyUSBDevice.begin(0);
+  TinyUSB_Device_Init(0);
 #endif
 
   usb_hid.enableOutEndpoint(true);

--- a/examples/HID/hid_generic_inout/hid_generic_inout.ino
+++ b/examples/HID/hid_generic_inout/hid_generic_inout.ino
@@ -52,7 +52,7 @@ void setup()
   Serial.begin(115200);
 
   // wait until device mounted
-  while( !USBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
 
   Serial.println("Adafruit TinyUSB HID Generic In Out example");
 }

--- a/examples/HID/hid_keyboard/hid_keyboard.ino
+++ b/examples/HID/hid_keyboard/hid_keyboard.ino
@@ -42,7 +42,7 @@ void setup()
 {
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
   // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
-  TinyUSBDevice.begin(0);
+  TinyUSB_Device_Init(0);
 #endif
 
   usb_hid.setPollInterval(2);

--- a/examples/HID/hid_keyboard/hid_keyboard.ino
+++ b/examples/HID/hid_keyboard/hid_keyboard.ino
@@ -40,6 +40,11 @@ uint8_t pincount = sizeof(pins)/sizeof(pins[0]);
 // the setup function runs once when you press reset or power the board
 void setup()
 {
+#if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
+  // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
+  TinyUSBDevice.begin(0);
+#endif
+
   usb_hid.setPollInterval(2);
   usb_hid.setReportDescriptor(desc_hid_report, sizeof(desc_hid_report));
   usb_hid.setReportCallback(NULL, hid_report_callback);

--- a/examples/HID/hid_keyboard/hid_keyboard.ino
+++ b/examples/HID/hid_keyboard/hid_keyboard.ino
@@ -58,7 +58,7 @@ void setup()
   }
 
   // wait until device mounted
-  while( !USBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
 }
 
 
@@ -68,11 +68,11 @@ void loop()
   delay(2);
 
 //  // Remote wakeup
-//  if ( USBDevice.suspended() && btn )
+//  if ( TinyUSBDevice.suspended() && btn )
 //  {
 //    // Wake up host if we are in suspend mode
 //    // and REMOTE_WAKEUP feature is enabled by host
-//    USBDevice.remoteWakeup();
+//    TinyUSBDevice.remoteWakeup();
 //  }
 
   if ( !usb_hid.ready() ) return;

--- a/examples/HID/hid_mouse/hid_mouse.ino
+++ b/examples/HID/hid_mouse/hid_mouse.ino
@@ -45,7 +45,7 @@ void setup()
 {
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
   // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
-  TinyUSBDevice.begin(0);
+  TinyUSB_Device_Init(0);
 #endif
 
   // Set up button, pullup opposite to active state

--- a/examples/HID/hid_mouse/hid_mouse.ino
+++ b/examples/HID/hid_mouse/hid_mouse.ino
@@ -55,7 +55,7 @@ void setup()
   Serial.begin(115200);
 
   // wait until device mounted
-  while( !USBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
 
   Serial.println("Adafruit TinyUSB HID Mouse example");
 }
@@ -72,11 +72,11 @@ void loop()
   if (!btn_pressed) return;
 
   // Remote wakeup
-  if ( USBDevice.suspended() )
+  if ( TinyUSBDevice.suspended() )
   {
     // Wake up host if we are in suspend mode
     // and REMOTE_WAKEUP feature is enabled by host
-    USBDevice.remoteWakeup();
+    TinyUSBDevice.remoteWakeup();
   }
 
   if ( usb_hid.ready() )

--- a/examples/HID/hid_mouse/hid_mouse.ino
+++ b/examples/HID/hid_mouse/hid_mouse.ino
@@ -43,6 +43,11 @@ Adafruit_USBD_HID usb_hid;
 // the setup function runs once when you press reset or power the board
 void setup()
 {
+#if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
+  // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
+  TinyUSBDevice.begin(0);
+#endif
+
   // Set up button, pullup opposite to active state
   pinMode(pin, activeState ? INPUT_PULLDOWN : INPUT_PULLUP);
 

--- a/examples/MIDI/midi_pizza_box_dj/midi_pizza_box_dj.ino
+++ b/examples/MIDI/midi_pizza_box_dj/midi_pizza_box_dj.ino
@@ -94,7 +94,7 @@ void setup() {
   for(uint8_t i=0; i<FRAMES; i++) lvl[i] = 256;
 
   // Wait until device is enumerated properly before sending MIDI message
-  while( !USBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/examples/MIDI/midi_test/midi_test.ino
+++ b/examples/MIDI/midi_test/midi_test.ino
@@ -40,7 +40,7 @@ void setup()
 {
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
   // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
-  TinyUSBDevice.begin(0);
+  TinyUSB_Device_Init(0);
 #endif
 
   pinMode(LED_BUILTIN, OUTPUT);

--- a/examples/MIDI/midi_test/midi_test.ino
+++ b/examples/MIDI/midi_test/midi_test.ino
@@ -56,7 +56,7 @@ void setup()
   Serial.begin(115200);
 
   // wait until device mounted
-  while( !USBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
 }
 
 void loop()

--- a/examples/MIDI/midi_test/midi_test.ino
+++ b/examples/MIDI/midi_test/midi_test.ino
@@ -38,6 +38,11 @@ byte note_sequence[] = {
 
 void setup()
 {
+#if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
+  // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
+  TinyUSBDevice.begin(0);
+#endif
+
   pinMode(LED_BUILTIN, OUTPUT);
   
   //usb_midi.setStringDescriptor("TinyUSB MIDI");
@@ -98,13 +103,25 @@ void loop()
 void handleNoteOn(byte channel, byte pitch, byte velocity)
 {
   // Log when a note is pressed.
-  Serial.printf("Note on: channel = %d, pitch = %d, velocity - %d", channel, pitch, velocity);
-  Serial.println();
+  Serial.print("Note on: channel = ");
+  Serial.print(channel);
+
+  Serial.print(" pitch = ");
+  Serial.print(pitch);
+
+  Serial.print(" velocity = ");
+  Serial.println(velocity);
 }
 
 void handleNoteOff(byte channel, byte pitch, byte velocity)
 {
   // Log when a note is released.
-  Serial.printf("Note off: channel = %d, pitch = %d, velocity - %d", channel, pitch, velocity);
-  Serial.println();
+  Serial.print("Note off: channel = ");
+  Serial.print(channel);
+
+  Serial.print(" pitch = ");
+  Serial.print(pitch);
+
+  Serial.print(" velocity = ");
+  Serial.println(velocity);
 }

--- a/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
+++ b/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
@@ -21,9 +21,15 @@ Adafruit_USBD_MSC usb_msc;
 // the setup function runs once when you press reset or power the board
 void setup()
 {
+#if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
+  // Manual begin() is required on unsupported BSP such as mbed rp2040
+  // VID/PID, Manufacturer & Product string also need to be set as well
+  TinyUSBDevice.begin(0);
+#endif
+
   // Set disk vendor id, product id and revision with string up to 8, 16, 4 characters respectively
   usb_msc.setID("Adafruit", "Mass Storage", "1.0");
-  
+
   // Set disk size
   usb_msc.setCapacity(DISK_BLOCK_NUM, DISK_BLOCK_SIZE);
 
@@ -32,7 +38,7 @@ void setup()
 
   // Set Lun ready (RAM disk is always ready)
   usb_msc.setUnitReady(true);
-  
+
   usb_msc.begin();
 
   Serial.begin(115200);
@@ -47,8 +53,8 @@ void loop()
 }
 
 // Callback invoked when received READ10 command.
-// Copy disk's data to buffer (up to bufsize) and 
-// return number of copied bytes (must be multiple of block size) 
+// Copy disk's data to buffer (up to bufsize) and
+// return number of copied bytes (must be multiple of block size)
 int32_t msc_read_cb (uint32_t lba, void* buffer, uint32_t bufsize)
 {
   uint8_t const* addr = msc_disk[lba];
@@ -58,7 +64,7 @@ int32_t msc_read_cb (uint32_t lba, void* buffer, uint32_t bufsize)
 }
 
 // Callback invoked when received WRITE10 command.
-// Process data in buffer to disk's storage and 
+// Process data in buffer to disk's storage and
 // return number of written bytes (must be multiple of block size)
 int32_t msc_write_cb (uint32_t lba, uint8_t* buffer, uint32_t bufsize)
 {

--- a/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
+++ b/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
@@ -23,7 +23,7 @@ void setup()
 {
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
   // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
-  TinyUSBDevice.begin(0);
+  TinyUSB_Device_Init(0);
 #endif
 
   // Set disk vendor id, product id and revision with string up to 8, 16, 4 characters respectively

--- a/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
+++ b/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
@@ -22,8 +22,7 @@ Adafruit_USBD_MSC usb_msc;
 void setup()
 {
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
-  // Manual begin() is required on unsupported BSP such as mbed rp2040
-  // VID/PID, Manufacturer & Product string also need to be set as well
+  // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
   TinyUSBDevice.begin(0);
 #endif
 

--- a/examples/MassStorage/msc_ramdisk_dual/msc_ramdisk_dual.ino
+++ b/examples/MassStorage/msc_ramdisk_dual/msc_ramdisk_dual.ino
@@ -21,6 +21,11 @@ Adafruit_USBD_MSC usb_msc;
 // the setup function runs once when you press reset or power the board
 void setup()
 {
+#if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
+  // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
+  TinyUSBDevice.begin(0);
+#endif
+
   usb_msc.setMaxLun(2);
   
   // Set disk size and callback for Logical Unit 0 (LUN 0)

--- a/examples/MassStorage/msc_ramdisk_dual/msc_ramdisk_dual.ino
+++ b/examples/MassStorage/msc_ramdisk_dual/msc_ramdisk_dual.ino
@@ -23,7 +23,7 @@ void setup()
 {
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
   // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
-  TinyUSBDevice.begin(0);
+  TinyUSB_Device_Init(0);
 #endif
 
   usb_msc.setMaxLun(2);

--- a/examples/WebUSB/webusb_rgb/webusb_rgb.ino
+++ b/examples/WebUSB/webusb_rgb/webusb_rgb.ino
@@ -68,7 +68,7 @@ void setup()
   pixels.show();
 
   // wait until device mounted
-  while( !USBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
 
   Serial.println("TinyUSB WebUSB RGB example");
 }

--- a/examples/WebUSB/webusb_serial/webusb_serial.ino
+++ b/examples/WebUSB/webusb_serial/webusb_serial.ino
@@ -38,6 +38,11 @@ int led_pin = LED_BUILTIN;
 // the setup function runs once when you press reset or power the board
 void setup()
 {
+#if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
+  // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
+  TinyUSBDevice.begin(0);
+#endif
+
   pinMode(led_pin, OUTPUT);
   digitalWrite(led_pin, LOW);
   
@@ -49,7 +54,7 @@ void setup()
   Serial.begin(115200);
 
   // wait until device mounted
-  while( !TinyUSBDevice.mounted() ) delay(1);
+  //while( !TinyUSBDevice.mounted() ) delay(1);
 
   Serial.println("TinyUSB WebUSB Serial example");
 }

--- a/examples/WebUSB/webusb_serial/webusb_serial.ino
+++ b/examples/WebUSB/webusb_serial/webusb_serial.ino
@@ -54,7 +54,7 @@ void setup()
   Serial.begin(115200);
 
   // wait until device mounted
-  //while( !TinyUSBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
 
   Serial.println("TinyUSB WebUSB Serial example");
 }

--- a/examples/WebUSB/webusb_serial/webusb_serial.ino
+++ b/examples/WebUSB/webusb_serial/webusb_serial.ino
@@ -40,7 +40,7 @@ void setup()
 {
 #if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
   // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
-  TinyUSBDevice.begin(0);
+  TinyUSB_Device_Init(0);
 #endif
 
   pinMode(led_pin, OUTPUT);

--- a/examples/WebUSB/webusb_serial/webusb_serial.ino
+++ b/examples/WebUSB/webusb_serial/webusb_serial.ino
@@ -49,7 +49,7 @@ void setup()
   Serial.begin(115200);
 
   // wait until device mounted
-  while( !USBDevice.mounted() ) delay(1);
+  while( !TinyUSBDevice.mounted() ) delay(1);
 
   Serial.println("TinyUSB WebUSB Serial example");
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit TinyUSB Library
-version=1.3.2
+version=1.3.3
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=TinyUSB library for Arduino

--- a/src/Adafruit_TinyUSB.h
+++ b/src/Adafruit_TinyUSB.h
@@ -45,7 +45,7 @@
 #include "arduino/webusb/Adafruit_USBD_WebUSB.h"
 
 // Initialize device hardware, stack, also Serial as CDC
-// Wrapper for USBDevice.begin(rhport)
+// Wrapper for TinyUSBDevice.begin(rhport)
 void TinyUSB_Device_Init(uint8_t rhport);
 
 #endif

--- a/src/arduino/Adafruit_TinyUSB_API.cpp
+++ b/src/arduino/Adafruit_TinyUSB_API.cpp
@@ -35,7 +35,7 @@ extern "C" {
 
 void TinyUSB_Device_Init(uint8_t rhport) {
   // Init USB Device controller and stack
-  USBDevice.begin(rhport);
+  TinyUSBDevice.begin(rhport);
 }
 
 // RP2040 has its own implementation since it needs mutex for dual core

--- a/src/arduino/Adafruit_USBD_CDC.cpp
+++ b/src/arduino/Adafruit_USBD_CDC.cpp
@@ -78,7 +78,7 @@ void Adafruit_USBD_CDC::begin(uint32_t baud) {
 
   _instance = _instance_count++;
   this->setStringDescriptor("TinyUSB Serial");
-  USBDevice.addInterface(*this);
+  TinyUSBDevice.addInterface(*this);
 }
 
 void Adafruit_USBD_CDC::begin(uint32_t baud, uint8_t config) {
@@ -88,7 +88,7 @@ void Adafruit_USBD_CDC::begin(uint32_t baud, uint8_t config) {
 
 void Adafruit_USBD_CDC::end(void) {
   // Reset configuration descriptor without Serial as CDC
-  USBDevice.clearConfiguration();
+  TinyUSBDevice.clearConfiguration();
   _instance_count = 0;
 }
 

--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -60,7 +60,7 @@
 
 enum { STRID_LANGUAGE = 0, STRID_MANUFACTURER, STRID_PRODUCT, STRID_SERIAL };
 
-Adafruit_USBD_Device USBDevice;
+Adafruit_USBD_Device TinyUSBDevice;
 
 Adafruit_USBD_Device::Adafruit_USBD_Device(void) {}
 
@@ -291,7 +291,7 @@ extern "C" {
 // Invoked when received GET DEVICE DESCRIPTOR
 // Application return pointer to descriptor
 uint8_t const *tud_descriptor_device_cb(void) {
-  return (uint8_t const *)&USBDevice._desc_device;
+  return (uint8_t const *)&TinyUSBDevice._desc_device;
 }
 
 // Invoked when received GET CONFIGURATION DESCRIPTOR
@@ -299,7 +299,7 @@ uint8_t const *tud_descriptor_device_cb(void) {
 // enough for transfer to complete
 uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
   (void)index;
-  return USBDevice._desc_cfg;
+  return TinyUSBDevice._desc_cfg;
 }
 
 // Invoked when received GET STRING DESCRIPTOR request
@@ -308,7 +308,7 @@ uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
 // OS 1.0 Descriptors.
 // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
 uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
-  return USBDevice.descriptor_string_cb(index, langid);
+  return TinyUSBDevice.descriptor_string_cb(index, langid);
 }
 
 } // extern C

--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -34,20 +34,42 @@
 // USB Information can be defined in variant file e.g pins_arduino.h
 #include "Arduino.h"
 
+// - USB_VID, USB_PID, USB_MANUFACTURER, USB_PRODUCT are defined on most
+// core that has built-in support for TinyUSB. Otherwise
+// - BOARD_VENDORID, BOARD_PRODUCTID, BOARD_MANUFACTURER, BOARD_NAME are use
+// if defined, mostly on mbed core
+
 #ifndef USB_VID
-#define USB_VID 0xcafe
+  #ifdef BOARD_VENDORID
+    #define USB_VID BOARD_VENDORID
+  #else
+    #define USB_VID 0x239a
+  #endif
 #endif
 
 #ifndef USB_PID
-#define USB_PID 0xcafe
+  #ifdef BOARD_PRODUCTID
+    #define USB_PID BOARD_PRODUCTID
+  #else
+    #define USB_PID 0xcafe
+  #endif
 #endif
 
 #ifndef USB_MANUFACTURER
-#define USB_MANUFACTURER "Unknown"
+
+  #ifdef BOARD_MANUFACTURER
+    #define USB_MANUFACTURER BOARD_MANUFACTURER
+  #else
+    #define USB_MANUFACTURER "Adafruit"
+  #endif
 #endif
 
 #ifndef USB_PRODUCT
-#define USB_PRODUCT "Unknown"
+  #ifdef BOARD_NAME
+    #define USB_PRODUCT BOARD_NAME
+  #else
+    #define USB_PRODUCT "Unknown"
+  #endif
 #endif
 
 #ifndef USB_LANGUAGE

--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -40,36 +40,36 @@
 // if defined, mostly on mbed core
 
 #ifndef USB_VID
-  #ifdef BOARD_VENDORID
-    #define USB_VID BOARD_VENDORID
-  #else
-    #define USB_VID 0x239a
-  #endif
+#ifdef BOARD_VENDORID
+#define USB_VID BOARD_VENDORID
+#else
+#define USB_VID 0x239a
+#endif
 #endif
 
 #ifndef USB_PID
-  #ifdef BOARD_PRODUCTID
-    #define USB_PID BOARD_PRODUCTID
-  #else
-    #define USB_PID 0xcafe
-  #endif
+#ifdef BOARD_PRODUCTID
+#define USB_PID BOARD_PRODUCTID
+#else
+#define USB_PID 0xcafe
+#endif
 #endif
 
 #ifndef USB_MANUFACTURER
 
-  #ifdef BOARD_MANUFACTURER
-    #define USB_MANUFACTURER BOARD_MANUFACTURER
-  #else
-    #define USB_MANUFACTURER "Adafruit"
-  #endif
+#ifdef BOARD_MANUFACTURER
+#define USB_MANUFACTURER BOARD_MANUFACTURER
+#else
+#define USB_MANUFACTURER "Adafruit"
+#endif
 #endif
 
 #ifndef USB_PRODUCT
-  #ifdef BOARD_NAME
-    #define USB_PRODUCT BOARD_NAME
-  #else
-    #define USB_PRODUCT "Unknown"
-  #endif
+#ifdef BOARD_NAME
+#define USB_PRODUCT BOARD_NAME
+#else
+#define USB_PRODUCT "Unknown"
+#endif
 #endif
 
 #ifndef USB_LANGUAGE

--- a/src/arduino/Adafruit_USBD_Device.h
+++ b/src/arduino/Adafruit_USBD_Device.h
@@ -107,6 +107,12 @@ private:
                                                   uint16_t langid);
 };
 
-extern Adafruit_USBD_Device USBDevice;
+extern Adafruit_USBD_Device TinyUSBDevice;
+
+// USBDevice has a high chance to conflict with other usb stack
+// only define if supported BSP
+#ifdef USE_TINYUSB
+#define USBDevice  TinyUSBDevice
+#endif
 
 #endif /* ADAFRUIT_USBD_DEVICE_H_ */

--- a/src/arduino/Adafruit_USBD_Device.h
+++ b/src/arduino/Adafruit_USBD_Device.h
@@ -112,7 +112,7 @@ extern Adafruit_USBD_Device TinyUSBDevice;
 // USBDevice has a high chance to conflict with other usb stack
 // only define if supported BSP
 #ifdef USE_TINYUSB
-#define USBDevice  TinyUSBDevice
+#define USBDevice TinyUSBDevice
 #endif
 
 #endif /* ADAFRUIT_USBD_DEVICE_H_ */

--- a/src/arduino/hid/Adafruit_USBD_HID.cpp
+++ b/src/arduino/hid/Adafruit_USBD_HID.cpp
@@ -108,7 +108,7 @@ uint16_t Adafruit_USBD_HID::getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
 }
 
 bool Adafruit_USBD_HID::begin(void) {
-  if (!USBDevice.addInterface(*this)) {
+  if (!TinyUSBDevice.addInterface(*this)) {
     return false;
   }
 

--- a/src/arduino/midi/Adafruit_USBD_MIDI.cpp
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.cpp
@@ -40,7 +40,7 @@ Adafruit_USBD_MIDI::Adafruit_USBD_MIDI(void) : _n_cables(1) {}
 void Adafruit_USBD_MIDI::setCables(uint8_t n_cables) { _n_cables = n_cables; }
 
 bool Adafruit_USBD_MIDI::begin(void) {
-  if (!USBDevice.addInterface(*this))
+  if (!TinyUSBDevice.addInterface(*this))
     return false;
 
   return true;

--- a/src/arduino/msc/Adafruit_USBD_MSC.cpp
+++ b/src/arduino/msc/Adafruit_USBD_MSC.cpp
@@ -87,7 +87,7 @@ void Adafruit_USBD_MSC::setReadyCallback(uint8_t lun, ready_callback_t cb) {
 }
 
 bool Adafruit_USBD_MSC::begin(void) {
-  if (!USBDevice.addInterface(*this)) {
+  if (!TinyUSBDevice.addInterface(*this)) {
     return false;
   }
 

--- a/src/arduino/ports/rp2040/Adafruit_TinyUSB_rp2040.cpp
+++ b/src/arduino/ports/rp2040/Adafruit_TinyUSB_rp2040.cpp
@@ -30,11 +30,11 @@
 
 // mbed old pico-sdk need to wrap with cpp
 extern "C" {
+#include "hardware/flash.h"
 #include "hardware/irq.h"
 #include "pico/bootrom.h"
 #include "pico/mutex.h"
 #include "pico/time.h"
-#include "hardware/flash.h"
 }
 
 #include "arduino/Adafruit_TinyUSB_API.h"
@@ -60,31 +60,27 @@ extern "C" {
 #include "mbed.h"
 static mbed::Ticker _usb_ticker;
 
-#define get_unique_id(_serial)    flash_get_unique_id(_serial)
+#define get_unique_id(_serial) flash_get_unique_id(_serial)
 
-static void ticker_task(void)
-{
-  irq_set_pending(USB_TASK_IRQ);
-}
+static void ticker_task(void) { irq_set_pending(USB_TASK_IRQ); }
 
-static void setup_periodic_usb_hanlder(uint64_t us)
-{
-  _usb_ticker.attach(ticker_task, (std::chrono::microseconds) us);
+static void setup_periodic_usb_hanlder(uint64_t us) {
+  _usb_ticker.attach(ticker_task, (std::chrono::microseconds)us);
 }
 
 #else
 
 #include "pico/unique_id.h"
 
-#define get_unique_id(_serial)    pico_get_unique_board_id((pico_unique_board_id_t *)_serial);
+#define get_unique_id(_serial)                                                 \
+  pico_get_unique_board_id((pico_unique_board_id_t *)_serial);
 
 static int64_t timer_task(__unused alarm_id_t id, __unused void *user_data) {
   irq_set_pending(USB_TASK_IRQ);
   return USB_TASK_INTERVAL;
 }
 
-static void setup_periodic_usb_hanlder(uint64_t us)
-{
+static void setup_periodic_usb_hanlder(uint64_t us) {
   add_alarm_in_us(us, timer_task, NULL, true);
 }
 
@@ -115,7 +111,7 @@ void TinyUSB_Port_InitDevice(uint8_t rhport) {
 
   irq_set_enabled(USBCTRL_IRQ, false);
   irq_handler_t current_handler = irq_get_exclusive_handler(USBCTRL_IRQ);
-  if(current_handler) {
+  if (current_handler) {
     irq_remove_handler(USBCTRL_IRQ, current_handler);
   }
 

--- a/src/arduino/ports/rp2040/tusb_config_rp2040.h
+++ b/src/arduino/ports/rp2040/tusb_config_rp2040.h
@@ -32,11 +32,7 @@ extern "C" {
 //--------------------------------------------------------------------
 // COMMON CONFIGURATION
 //--------------------------------------------------------------------
-#ifdef USE_TINYUSB
 #define CFG_TUSB_RHPORT0_MODE OPT_MODE_DEVICE
-#else
-#define CFG_TUSB_RHPORT0_MODE OPT_MODE_NONE
-#endif
 
 #ifndef CFG_TUSB_MCU
 #define CFG_TUSB_MCU OPT_MCU_RP2040

--- a/src/arduino/webusb/Adafruit_USBD_WebUSB.cpp
+++ b/src/arduino/webusb/Adafruit_USBD_WebUSB.cpp
@@ -127,11 +127,11 @@ Adafruit_USBD_WebUSB::Adafruit_USBD_WebUSB(void) {
 }
 
 bool Adafruit_USBD_WebUSB::begin(void) {
-  if (!USBDevice.addInterface(*this))
+  if (!TinyUSBDevice.addInterface(*this))
     return false;
 
   // WebUSB requires to change USB version from 2.0 to 2.1
-  USBDevice.setVersion(0x0210);
+  TinyUSBDevice.setVersion(0x0210);
 
   _webusb_dev = this;
   return true;


### PR DESCRIPTION
This PR provide intial/experimental support for mbed core for rp2040 (core without built-in support). It is usable with TinyUSB, with a bit of limit such as: 
- `TinyUSB_Device_Init()` need to be manually called in setup()
- `TinyUSB_Device_Task()` and/or `TinyUSB_Device_FlushCDC()` may (or not) need to be manually called in loop()
- Use `SerialTinyUSB` name instead of Serial for serial monitor
- And there could be more other issues, using on these cores should be considered as experimental

Readme.md has been updated to clearly categorize core with and without built-in support.

I have tested with stock example: msc_ramdisk, hid_mouse/keyboard, midi_test, all seems to be working fine. However, since TinyUSB library **steal** all the usb packet/control and irq handler from mbed core, There may (or not) be issue when using it in the long run (remains to be seen). Anyway it is nice for user to have this option, we will see if it is a needed one.