### PR TITLE
Hint platform io to not statically link

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,4 @@
+{"build": {
+    "libArchive": false
+  }
+}


### PR DESCRIPTION
- Platform IO defaults to building all the libraries statically linked, this appears to prevent the Serial port from working on nrf52840

NOTE! This is almost certainly not how this should be resolved, the underlying issue is likely on how some of the symbols that configure the serial driver are handled