### PR TITLE
Newline generates a wrong keycode

### DIFF
--- a/src/class/hid/hid.h
+++ b/src/class/hid/hid.h
@@ -871,10 +871,10 @@ enum
     {0, 0                     }, /* 0x07           */ \
     {0, HID_KEY_BACKSPACE     }, /* 0x08 Backspace */ \
     {0, HID_KEY_TAB           }, /* 0x09 Tab       */ \
-    {0, HID_KEY_RETURN        }, /* 0x0A Line Feed */ \
+    {0, HID_KEY_ENTER         }, /* 0x0A Line Feed */ \
     {0, 0                     }, /* 0x0B           */ \
     {0, 0                     }, /* 0x0C           */ \
-    {0, HID_KEY_RETURN        }, /* 0x0D CR        */ \
+    {0, HID_KEY_ENTER         }, /* 0x0D CR        */ \
     {0, 0                     }, /* 0x0E           */ \
     {0, 0                     }, /* 0x0F           */ \
     {0, 0                     }, /* 0x10           */ \


### PR DESCRIPTION
CR/LF was translating to keycode 0x9E, which is ignored by MacOS and Android. I have not tried other OSes. It should be keycode 0x28. 