### PR TITLE
rough fix for linux serial clients hanging while talking to nrf52 cdcserial

### DIFF
--- a/src/class/cdc/cdc_device.c
+++ b/src/class/cdc/cdc_device.c
@@ -466,7 +466,7 @@ bool cdcd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_
     {
       // If there is no data left, a ZLP should be sent if
       // xferred_bytes is multiple of EP Packet size and not zero
-      if ( !tu_fifo_count(&p_cdc->tx_ff) && xferred_bytes && (0 == (xferred_bytes & (BULK_PACKET_SIZE-1))) )
+      if ( !tu_fifo_count(&p_cdc->tx_ff) /* && xferred_bytes && (0 == (xferred_bytes & (BULK_PACKET_SIZE-1))) */)
       {
         if ( usbd_edpt_claim(rhport, p_cdc->ep_in) )
         {


### PR DESCRIPTION
Hi, 

Disclaimer: I'm not sure if this is the cleanest possible fix for the problem (because I admittedly haven't looked through your entire spiffy lib in detail).  But I wanted to report the problem and the fix I made and have now tested on a number of devices.  Any feedback would be appreciated...

Problem statement:
Sometimes characters written from the nrf52 pseudo serial device to a linux
host would stop showing up on the linux app side.  This occurred randomly
but typically within a few minutes after starting a session.

The reading from linux
would remain 'hung' until you type a character on the linux side (thus
doing a new write TOWARDS the nrf52).

Theory: it seemed like something was getting hung on the linux side waiting
on a response to a read.  This led me to this code.  If I changed the code
to always send a response to any read from ep_in (rather than opting to not
send a response at all in some circumstances), "screen" apps stopped hanging.

Notes:
* problem reproducable with 'screen /dev/ttyACM0 921600' or other serial
clients (I initially used the meshtastic-python app)
* It is a _long_ time since I've messed with USB code and my analysis is
probably pretty sloppy here.  But I wanted it report it upstream in case
it is useful for others.  If there is a better fix for this problem (likely)
I'd love to change to it.

'fixes' https://github.com/meshtastic/Meshtastic-device/issues/838