### PR TITLE
Gamepad descriptor didn't work on Android phones

### DIFF
--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -312,45 +312,48 @@ static inline bool  tud_hid_gamepad_report(uint8_t report_id, int8_t x, int8_t y
 // Gamepad Report Descriptor Template
 // with 16 buttons, 2 joysticks and 1 hat/dpad with following layout
 // | X | Y | Z | Rz | Rx | Ry (1 byte each) | hat/DPAD (1 byte) | Button Map (2 bytes) |
-#define TUD_HID_REPORT_DESC_GAMEPAD(...) \
-  HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )                 ,\
-  HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )                 ,\
-  HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,\
-    /* Report ID if any */\
-    __VA_ARGS__ \
-    /* 8 bit X, Y, Z, Rz, Rx, Ry (min -127, max 127 ) */ \
-    HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_X                    ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_Y                    ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_Z                    ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_RZ                   ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_RX                   ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_RY                   ) ,\
-    HID_LOGICAL_MIN  ( 0x81                                   ) ,\
-    HID_LOGICAL_MAX  ( 0x7f                                   ) ,\
-    HID_REPORT_COUNT ( 6                                      ) ,\
-    HID_REPORT_SIZE  ( 8                                      ) ,\
-    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* 8 bit DPad/Hat Button Map  */ \
-    HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
-    HID_LOGICAL_MIN  ( 1                                      ) ,\
-    HID_LOGICAL_MAX  ( 8                                      ) ,\
-    HID_PHYSICAL_MIN ( 0                                      ) ,\
-    HID_PHYSICAL_MAX_N ( 315, 2                               ) ,\
-    HID_REPORT_COUNT ( 1                                      ) ,\
-    HID_REPORT_SIZE  ( 8                                      ) ,\
-    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* 16 bit Button Map */ \
-    HID_USAGE_PAGE   ( HID_USAGE_PAGE_BUTTON                  ) ,\
-    HID_USAGE_MIN    ( 1                                      ) ,\
-    HID_USAGE_MAX    ( 32                                     ) ,\
-    HID_LOGICAL_MIN  ( 0                                      ) ,\
-    HID_LOGICAL_MAX  ( 1                                      ) ,\
-    HID_REPORT_COUNT ( 32                                     ) ,\
-    HID_REPORT_SIZE  ( 1                                      ) ,\
-    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-  HID_COLLECTION_END \
+#define TUD_HID_REPORT_DESC_GAMEPAD(...)                               \
+  HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )                       ,\
+  HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )                       ,\
+  HID_COLLECTION ( HID_COLLECTION_APPLICATION )                       ,\
+    /* Report ID if any */                                             \
+    __VA_ARGS__                                                        \
+    HID_USAGE (HID_USAGE_DESKTOP_POINTER)                             ,\
+      HID_COLLECTION ( HID_COLLECTION_PHYSICAL )                      ,\
+        /* 8 bit X, Y, Z, Rz, Rx, Ry (min -127, max 127 ) */           \
+        HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
+          HID_USAGE        ( HID_USAGE_DESKTOP_X                    ) ,\
+          HID_USAGE        ( HID_USAGE_DESKTOP_Y                    ) ,\
+          HID_USAGE        ( HID_USAGE_DESKTOP_Z                    ) ,\
+          HID_USAGE        ( HID_USAGE_DESKTOP_RZ                   ) ,\
+          HID_USAGE        ( HID_USAGE_DESKTOP_RX                   ) ,\
+          HID_USAGE        ( HID_USAGE_DESKTOP_RY                   ) ,\
+          HID_LOGICAL_MIN  ( 0x81                                   ) ,\
+          HID_LOGICAL_MAX  ( 0x7f                                   ) ,\
+          HID_REPORT_COUNT ( 6                                      ) ,\
+          HID_REPORT_SIZE  ( 8                                      ) ,\
+          HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+        /* 8 bit DPad/Hat Button Map  */                               \
+        HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
+          HID_USAGE        ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
+          HID_LOGICAL_MIN  ( 1                                      ) ,\
+          HID_LOGICAL_MAX  ( 8                                      ) ,\
+          HID_PHYSICAL_MIN ( 0                                      ) ,\
+          HID_PHYSICAL_MAX_N ( 315, 2                               ) ,\
+          HID_REPORT_COUNT ( 1                                      ) ,\
+          HID_REPORT_SIZE  ( 8                                      ) ,\
+          HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+        /* 16 bit Button Map */                                        \
+        HID_USAGE_PAGE     ( HID_USAGE_PAGE_BUTTON                  ) ,\
+          HID_USAGE_MIN    ( 1                                      ) ,\
+          HID_USAGE_MAX    ( 32                                     ) ,\
+          HID_LOGICAL_MIN  ( 0                                      ) ,\
+          HID_LOGICAL_MAX  ( 1                                      ) ,\
+          HID_REPORT_COUNT ( 32                                     ) ,\
+          HID_REPORT_SIZE  ( 1                                      ) ,\
+          HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+      HID_COLLECTION_END                                              ,\
+  HID_COLLECTION_END                                                   \
 
 // HID Generic Input & Output
 // - 1st parameter is report size (mandatory)

--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -318,8 +318,8 @@ static inline bool  tud_hid_gamepad_report(uint8_t report_id, int8_t x, int8_t y
   HID_COLLECTION ( HID_COLLECTION_APPLICATION )                       ,\
     /* Report ID if any */                                             \
     __VA_ARGS__                                                        \
-    HID_USAGE (HID_USAGE_DESKTOP_POINTER)                             ,\
-      HID_COLLECTION ( HID_COLLECTION_PHYSICAL )                      ,\
+    HID_USAGE (HID_USAGE_DESKTOP_GAMEPAD)                             ,\
+      HID_COLLECTION ( HID_COLLECTION_LOGICAL  )                      ,\
         /* 8 bit X, Y, Z, Rz, Rx, Ry (min -127, max 127 ) */           \
         HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
           HID_USAGE        ( HID_USAGE_DESKTOP_X                    ) ,\


### PR DESCRIPTION
Issue: The communication between the Gamepad and an Android phone was lost after connecting. 
Solution: It was needed to add HID_USAGE_DESKTOP_POINTER and HID_COLLECTION_PHYSICAL to the gamepad descriptor for allowing connectivity with Android devices. These changes were inspired by [this repo](https://github.com/tcoppex/mbed-ble-hid/blob/master/src/services/HIDGamepadService.cpp) made by @tcoppex.

I would like to really thank @hathach the great work done bringing the BLE communication Gamepad support to Arduino. 

I have not an IOS device to test these changes, but at least now it works for Android.

EDIT: Using HID_COLLECTION_LOGICAL instead of HID_COLLECTION_PHYSICAL looks like improves the response. Also I substituted HID_USAGE_DESKTOP_POINTER by HID_USAGE_DESKTOP_GAMEPAD, in this case I don't know if this is correct but it works.