### PR TITLE
set sense code to NOT READY (medium not found) when unit is not ready

### DIFF
--- a/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
+++ b/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
@@ -70,7 +70,7 @@ void setup()
 
 void loop()
 {
-
+  // nothing to do
 }
 
 // Callback invoked when received READ10 command.

--- a/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
+++ b/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
@@ -18,6 +18,22 @@
 
 Adafruit_USBD_MSC usb_msc;
 
+// Eject button to demonstrate medium is not ready e.g SDCard is not present
+// whenever this button is pressed and hold, it will report to host as not ready
+#if defined(ARDUINO_SAMD_CIRCUITPLAYGROUND_EXPRESS) || defined(ARDUINO_NRF52840_CIRCUITPLAY)
+  #define BTN_EJECT   4   // Left Button
+  bool activeState = true;
+
+#elif defined(ARDUINO_FUNHOUSE_ESP32S2)
+  #define BTN_EJECT   BUTTON_DOWN
+  bool activeState = true;
+
+#elif defined PIN_BUTTON1
+  #define BTN_EJECT   PIN_BUTTON1
+  bool activeState = false;
+#endif
+
+
 // the setup function runs once when you press reset or power the board
 void setup()
 { 
@@ -39,6 +55,11 @@ void setup()
   // Set Lun ready (RAM disk is always ready)
   usb_msc.setUnitReady(true);
 
+#ifdef BTN_EJECT
+  pinMode(BTN_EJECT, activeState ? INPUT_PULLDOWN : INPUT_PULLUP);
+  usb_msc.setReadyCallback(msc_ready_callback);
+#endif
+
   usb_msc.begin();
 
   Serial.begin(115200);
@@ -49,9 +70,7 @@ void setup()
 
 void loop()
 {
-  // nothing to do
-  Serial.println("Adafruit TinyUSB Mass Storage RAM Disk example");
-  delay(1000);
+
 }
 
 // Callback invoked when received READ10 command.
@@ -82,3 +101,14 @@ void msc_flush_callback (void)
 {
   // nothing to do
 }
+
+
+#ifdef BTN_EJECT
+// Invoked when received Test Unit Ready command.
+// return true allowing host to read/write this LUN e.g SD card inserted
+bool msc_ready_callback(void)
+{
+  // button not active --> medium ready
+  return digitalRead(BTN_EJECT) != activeState;
+}
+#endif

--- a/src/arduino/msc/Adafruit_USBD_MSC.cpp
+++ b/src/arduino/msc/Adafruit_USBD_MSC.cpp
@@ -173,7 +173,14 @@ bool tud_msc_test_unit_ready_cb(uint8_t lun) {
     _msc_dev->_lun_info[lun].unit_ready = _msc_dev->_lun_info[lun].ready_cb();
   }
 
-  return _msc_dev->_lun_info[lun].unit_ready;
+  bool const ret = _msc_dev->_lun_info[lun].unit_ready;
+
+  if (!ret) {
+    // Addition Sense: 3A-00 is NOT FOUND
+    tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x3a, 0x00);
+  }
+
+  return ret;
 }
 
 // Callback invoked to determine disk's size


### PR DESCRIPTION
- add button eject to demonstrate setReadyCallback() in msc_ramdisk example

@ladyada this is example to report floppy disk removed/attached. We could either use an 
- callback with `msc.setReadyCallback()` where tinyusb will ask for state of the disk each time it needs. Or 
- actively set the disk status with `usb.setUnitReady()` if you have an interrupt that detect the attached/removed of the disk.