### PR TITLE
Enhance MSC multiple LUN with dynamic medium removal support

### DIFF
--- a/examples/MassStorage/msc_external_flash_sdcard/msc_external_flash_sdcard.ino
+++ b/examples/MassStorage/msc_external_flash_sdcard/msc_external_flash_sdcard.ino
@@ -138,7 +138,9 @@ bool init_sdcard(void)
 
   if ( !sd.begin(SDCARD_CS, SD_SCK_MHZ(50)) )
   {
-    Serial.print("Failed");
+    Serial.print("Failed ");
+    sd.errorPrint();
+
     return false;
   }
 
@@ -149,7 +151,7 @@ bool init_sdcard(void)
   sd_changed = true; // to print contents initially
 
   Serial.print("OK, Card size = ");
-  Serial.print(block_count * 512 / (1024*1024));
+  Serial.print((block_count / (1024*1024)) * 512);
   Serial.println(" MB");
 
   return true;

--- a/examples/MassStorage/msc_external_flash_sdcard/msc_external_flash_sdcard.ino
+++ b/examples/MassStorage/msc_external_flash_sdcard/msc_external_flash_sdcard.ino
@@ -24,6 +24,10 @@
 #include "Adafruit_SPIFlash.h"
 #include "Adafruit_TinyUSB.h"
 
+//--------------------------------------------------------------------+
+// External Flash Config
+//--------------------------------------------------------------------+
+
 // Uncomment to run example with FRAM
 // #define FRAM_CS   A5
 // #define FRAM_SPI  SPI
@@ -55,12 +59,23 @@
 
 Adafruit_SPIFlash flash(&flashTransport);
 
-// File system object on external flash from SdFat
+// External Flash File system
 FatFileSystem fatfs;
 
-const int chipSelect = 10;
+//--------------------------------------------------------------------+
+// SDCard Config
+//--------------------------------------------------------------------+
 
-// File system on SD Card
+#if defined(ARDUINO_PYPORTAL_M4) || defined(ARDUINO_PYPORTAL_M4_TITANO)
+  // PyPortal has on-board card reader
+  #define SDCARD_CS       32
+  #define SDCARD_DETECT   33
+#else
+  #define SDCARD_CS       10
+  // no detect
+#endif
+
+// SDCard File system
 SdFat sd;
 
 // USB Mass Storage object
@@ -68,6 +83,7 @@ Adafruit_USBD_MSC usb_msc;
 
 // Set to true when PC write to flash
 bool sd_changed = false;
+bool sd_inited = false;
 bool flash_changed = false;
 
 // the setup function runs once when you press reset or power the board
@@ -75,7 +91,9 @@ void setup()
 {
   pinMode(LED_BUILTIN, OUTPUT);
 
-  // MSC with 2 Logical Units
+  Serial.begin(115200);
+
+  // MSC with 2 Logical Units: LUN0: External Flash, LUN1: SDCard
   usb_msc.setMaxLun(2);
 
   usb_msc.setID(0, "Adafruit", "External Flash", "1.0");
@@ -98,21 +116,43 @@ void setup()
   flash_changed = true; // to print contents initially
 
   //------------- Lun 1 for SD card -------------//
-  if ( sd.begin(chipSelect, SD_SCK_MHZ(50)) )
-  {
-    uint32_t block_count = sd.card()->cardSize();
-    usb_msc.setCapacity(1, block_count, 512);
-    usb_msc.setReadWriteCallback(1, sdcard_read_cb, sdcard_write_cb, sdcard_flush_cb);
-    usb_msc.setUnitReady(1, true);
+#ifdef SDCARD_DETECT
+  // DETECT pin is available, detect card present on the fly with test unit ready
+  pinMode(SDCARD_DETECT, INPUT);
+  usb_msc.setReadyCallback(1, sdcard_ready_callback);
+#else
+  // no DETECT pin, card must be inserted when powered on
+  init_sdcard();
+  sd_inited = true;
+  usb_msc.setUnitReady(1, true);
+#endif
 
-    sd_changed = true; // to print contents initially
-  }
-
-  Serial.begin(115200);
-  //while ( !Serial ) delay(10);   // wait for native usb
-
+//  while ( !Serial ) delay(10);   // wait for native usb
   Serial.println("Adafruit TinyUSB Mass Storage External Flash + SD Card example");
   delay(1000);
+}
+
+bool init_sdcard(void)
+{
+  Serial.print("Init SDCard ... ");
+
+  if ( !sd.begin(SDCARD_CS, SD_SCK_MHZ(50)) )
+  {
+    Serial.print("Failed");
+    return false;
+  }
+
+  uint32_t block_count = sd.card()->cardSize();
+  usb_msc.setCapacity(1, block_count, 512);
+  usb_msc.setReadWriteCallback(1, sdcard_read_cb, sdcard_write_cb, sdcard_flush_cb);
+
+  sd_changed = true; // to print contents initially
+
+  Serial.print("OK, Card size = ");
+  Serial.print(block_count * 512 / (1024*1024));
+  Serial.println(" MB");
+
+  return true;
 }
 
 void print_rootdir(File* rdir)
@@ -203,6 +243,31 @@ void sdcard_flush_cb (void)
 
   digitalWrite(LED_BUILTIN, LOW);
 }
+
+#ifdef SDCARD_DETECT
+// Invoked when received Test Unit Ready command.
+// return true allowing host to read/write this LUN e.g SD card inserted
+bool sdcard_ready_callback(void)
+{
+  // Card is inserted
+  if ( digitalRead(SDCARD_DETECT) == HIGH )
+  {
+    // init SD card if not already
+    if ( !sd_inited )
+    {
+      sd_inited = init_sdcard();
+    }
+  }else
+  {
+    sd_inited = false;
+    usb_msc.setReadWriteCallback(1, NULL, NULL, NULL);
+  }
+
+  Serial.println(sd_inited);
+
+  return sd_inited;
+}
+#endif
 
 //--------------------------------------------------------------------+
 // External Flash callbacks

--- a/src/arduino/msc/Adafruit_USBD_MSC.cpp
+++ b/src/arduino/msc/Adafruit_USBD_MSC.cpp
@@ -200,13 +200,9 @@ void tud_msc_capacity_cb(uint8_t lun, uint32_t *block_count,
 int32_t tud_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer,
                         uint16_t bufsize) {
   const void *response = NULL;
-  uint16_t resplen = 0;
+  int32_t resplen = 0;
 
   switch (scsi_cmd[0]) {
-  case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
-    // Host is about to read/write etc ... better not to disconnect disk
-    resplen = 0;
-    break;
 
   default:
     // Set Sense = Invalid Command Operation
@@ -224,7 +220,7 @@ int32_t tud_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer,
   }
 
   // copy response to stack's buffer if any
-  if (response && resplen) {
+  if (response && (resplen > 0) ) {
     memcpy(buffer, response, resplen);
   }
 

--- a/src/arduino/msc/Adafruit_USBD_MSC.cpp
+++ b/src/arduino/msc/Adafruit_USBD_MSC.cpp
@@ -220,7 +220,7 @@ int32_t tud_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer,
   }
 
   // copy response to stack's buffer if any
-  if (response && (resplen > 0) ) {
+  if (response && (resplen > 0)) {
     memcpy(buffer, response, resplen);
   }
 

--- a/src/class/hid/hid_device.h
+++ b/src/class/hid/hid_device.h
@@ -310,8 +310,8 @@ static inline bool  tud_hid_gamepad_report(uint8_t report_id, int8_t x, int8_t y
   HID_COLLECTION_END \
 
 // Gamepad Report Descriptor Template
-// with 16 buttons, 2 joysticks and 1 hat/dpad with following layout
-// | X | Y | Z | Rz | Rx | Ry (1 byte each) | hat/DPAD (1 byte) | Button Map (2 bytes) |
+// with 32 buttons, 2 joysticks and 1 hat/dpad with following layout
+// | X | Y | Z | Rz | Rx | Ry (1 byte each) | hat/DPAD (1 byte) | Button Map (4 bytes) |
 #define TUD_HID_REPORT_DESC_GAMEPAD(...) \
   HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )                 ,\
   HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )                 ,\
@@ -319,37 +319,37 @@ static inline bool  tud_hid_gamepad_report(uint8_t report_id, int8_t x, int8_t y
     /* Report ID if any */\
     __VA_ARGS__ \
     /* 8 bit X, Y, Z, Rz, Rx, Ry (min -127, max 127 ) */ \
-    HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_X                    ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_Y                    ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_Z                    ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_RZ                   ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_RX                   ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_RY                   ) ,\
-    HID_LOGICAL_MIN  ( 0x81                                   ) ,\
-    HID_LOGICAL_MAX  ( 0x7f                                   ) ,\
-    HID_REPORT_COUNT ( 6                                      ) ,\
-    HID_REPORT_SIZE  ( 8                                      ) ,\
-    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_X                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_Y                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_Z                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RZ                   ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RX                   ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RY                   ) ,\
+    HID_LOGICAL_MIN    ( 0x81                                   ) ,\
+    HID_LOGICAL_MAX    ( 0x7f                                   ) ,\
+    HID_REPORT_COUNT   ( 6                                      ) ,\
+    HID_REPORT_SIZE    ( 8                                      ) ,\
+    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
     /* 8 bit DPad/Hat Button Map  */ \
-    HID_USAGE_PAGE   ( HID_USAGE_PAGE_DESKTOP                 ) ,\
-    HID_USAGE        ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
-    HID_LOGICAL_MIN  ( 1                                      ) ,\
-    HID_LOGICAL_MAX  ( 8                                      ) ,\
-    HID_PHYSICAL_MIN ( 0                                      ) ,\
-    HID_PHYSICAL_MAX_N ( 315, 2                               ) ,\
-    HID_REPORT_COUNT ( 1                                      ) ,\
-    HID_REPORT_SIZE  ( 8                                      ) ,\
-    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* 16 bit Button Map */ \
-    HID_USAGE_PAGE   ( HID_USAGE_PAGE_BUTTON                  ) ,\
-    HID_USAGE_MIN    ( 1                                      ) ,\
-    HID_USAGE_MAX    ( 32                                     ) ,\
-    HID_LOGICAL_MIN  ( 0                                      ) ,\
-    HID_LOGICAL_MAX  ( 1                                      ) ,\
-    HID_REPORT_COUNT ( 32                                     ) ,\
-    HID_REPORT_SIZE  ( 1                                      ) ,\
-    HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
+    HID_LOGICAL_MIN    ( 1                                      ) ,\
+    HID_LOGICAL_MAX    ( 8                                      ) ,\
+    HID_PHYSICAL_MIN   ( 0                                      ) ,\
+    HID_PHYSICAL_MAX_N ( 315, 2                                 ) ,\
+    HID_REPORT_COUNT   ( 1                                      ) ,\
+    HID_REPORT_SIZE    ( 8                                      ) ,\
+    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    /* 32 bit Button Map */ \
+    HID_USAGE_PAGE     ( HID_USAGE_PAGE_BUTTON                  ) ,\
+    HID_USAGE_MIN      ( 1                                      ) ,\
+    HID_USAGE_MAX      ( 32                                     ) ,\
+    HID_LOGICAL_MIN    ( 0                                      ) ,\
+    HID_LOGICAL_MAX    ( 1                                      ) ,\
+    HID_REPORT_COUNT   ( 32                                     ) ,\
+    HID_REPORT_SIZE    ( 1                                      ) ,\
+    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
   HID_COLLECTION_END \
 
 // HID Generic Input & Output

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -209,7 +209,7 @@ TU_ATTR_UNUSED static tu_lookup_entry_t const _msc_scsi_cmd_lookup[] =
   { .key = SCSI_CMD_MODE_SELECT_6                , .data = "Mode_Select 6" },
   { .key = SCSI_CMD_MODE_SENSE_6                 , .data = "Mode_Sense 6" },
   { .key = SCSI_CMD_START_STOP_UNIT              , .data = "Start Stop Unit" },
-  { .key = SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL , .data = "Prevent Allow Medium Removal" },
+  { .key = SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL , .data = "Prevent/Allow Medium Removal" },
   { .key = SCSI_CMD_READ_CAPACITY_10             , .data = "Read Capacity10" },
   { .key = SCSI_CMD_REQUEST_SENSE                , .data = "Request Sense" },
   { .key = SCSI_CMD_READ_FORMAT_CAPACITY         , .data = "Read Format Capacity" },
@@ -239,7 +239,7 @@ bool tud_msc_set_sense(uint8_t lun, uint8_t sense_key, uint8_t add_sense_code, u
   return true;
 }
 
-static inline void set_default_error_sense(uint8_t lun)
+static inline void set_sense_medium_not_present(uint8_t lun)
 {
   // default sense is NOT READY, MEDIUM NOT PRESENT
   tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x3A, 0x00);
@@ -661,7 +661,7 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
         resplen = - 1;
 
         // set default sense if not set by callback
-        if ( p_msc->sense_key == 0 ) set_default_error_sense(lun);
+        if ( p_msc->sense_key == 0 ) set_sense_medium_not_present(lun);
       }
     break;
 
@@ -677,7 +677,7 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
           resplen = - 1;
 
           // set default sense if not set by callback
-          if ( p_msc->sense_key == 0 ) set_default_error_sense(lun);
+          if ( p_msc->sense_key == 0 ) set_sense_medium_not_present(lun);
         }
       }
     break;
@@ -698,12 +698,12 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
         resplen = -1;
 
         // set default sense if not set by callback
-        if ( p_msc->sense_key == 0 ) set_default_error_sense(lun);
+        if ( p_msc->sense_key == 0 ) set_sense_medium_not_present(lun);
       }else
       {
         scsi_read_capacity10_resp_t read_capa10;
 
-        read_capa10.last_lba  = tu_htonl(block_count-1);
+        read_capa10.last_lba   = tu_htonl(block_count-1);
         read_capa10.block_size = tu_htonl(block_size);
 
         resplen = sizeof(read_capa10);
@@ -734,7 +734,7 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
         resplen = -1;
 
         // set default sense if not set by callback
-        if ( p_msc->sense_key == 0 ) set_default_error_sense(lun);
+        if ( p_msc->sense_key == 0 ) set_sense_medium_not_present(lun);
       }else
       {
         read_fmt_capa.block_num = tu_htonl(block_count);
@@ -847,7 +847,7 @@ static void proc_read10_cmd(uint8_t rhport, mscd_interface_t* p_msc)
     TU_LOG(MSC_DEBUG, "  tud_msc_read10_cb() return -1\r\n");
 
     // set sense
-    set_default_error_sense(p_cbw->lun);
+    set_sense_medium_not_present(p_cbw->lun);
 
     fail_scsi_op(rhport, p_msc, MSC_CSW_STATUS_FAILED);
   }
@@ -912,7 +912,7 @@ static void proc_write10_new_data(uint8_t rhport, mscd_interface_t* p_msc, uint3
     p_msc->xferred_len += xferred_bytes;
 
     // Set sense
-    set_default_error_sense(p_cbw->lun);
+    set_sense_medium_not_present(p_cbw->lun);
 
     fail_scsi_op(rhport, p_msc, MSC_CSW_STATUS_FAILED);
   }else

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -239,6 +239,12 @@ bool tud_msc_set_sense(uint8_t lun, uint8_t sense_key, uint8_t add_sense_code, u
   return true;
 }
 
+static inline void set_default_error_sense(uint8_t lun)
+{
+  // default sense is NOT READY, MEDIUM NOT PRESENT
+  tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x3A, 0x00);
+}
+
 //--------------------------------------------------------------------+
 // USBD Driver API
 //--------------------------------------------------------------------+
@@ -406,7 +412,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
         return false;
       }
 
-      TU_LOG(MSC_DEBUG, "  SCSI Command: %s\r\n", tu_lookup_find(&_msc_scsi_cmd_table, p_cbw->command[0]));
+      TU_LOG(MSC_DEBUG, "  SCSI Command [Lun%u]: %s\r\n", p_cbw->lun, tu_lookup_find(&_msc_scsi_cmd_table, p_cbw->command[0]));
       //TU_LOG_MEM(MSC_DEBUG, p_cbw, xferred_bytes, 2);
 
       p_csw->signature    = MSC_CSW_SIGNATURE;
@@ -473,7 +479,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
           if ( resplen < 0 )
           {
             // unsupported command
-            TU_LOG(MSC_DEBUG, "  SCSI unsupported command\r\n");
+            TU_LOG(MSC_DEBUG, "  SCSI unsupported or failed command\r\n");
             fail_scsi_op(rhport, p_msc, MSC_CSW_STATUS_FAILED);
           }
           else if (resplen == 0)
@@ -508,7 +514,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
     break;
 
     case MSC_STAGE_DATA:
-      TU_LOG(MSC_DEBUG, "  SCSI Data\r\n");
+      TU_LOG(MSC_DEBUG, "  SCSI Data [Lun%u]\r\n", p_cbw->lun);
       //TU_LOG_MEM(MSC_DEBUG, _mscd_buf, xferred_bytes, 2);
 
       if (SCSI_CMD_READ_10 == p_cbw->command[0])
@@ -569,7 +575,7 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
       // Wait for the Status phase to complete
       if( (ep_addr == p_msc->ep_in) && (xferred_bytes == sizeof(msc_csw_t)) )
       {
-        TU_LOG(MSC_DEBUG, "  SCSI Status = %u\r\n", p_csw->status);
+        TU_LOG(MSC_DEBUG, "  SCSI Status [Lun%u] = %u\r\n", p_cbw->lun, p_csw->status);
         // TU_LOG_MEM(MSC_DEBUG, p_csw, xferred_bytes, 2);
 
         // Invoke complete callback if defined
@@ -654,8 +660,8 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
         // Failed status response
         resplen = - 1;
 
-        // If sense key is not set by callback, default to Logical Unit Not Ready, Cause Not Reportable
-        if ( p_msc->sense_key == 0 ) tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x04, 0x00);
+        // set default sense if not set by callback
+        if ( p_msc->sense_key == 0 ) set_default_error_sense(lun);
       }
     break;
 
@@ -670,8 +676,8 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
           // Failed status response
           resplen = - 1;
 
-          // If sense key is not set by callback, default to Logical Unit Not Ready, Cause Not Reportable
-          if ( p_msc->sense_key == 0 ) tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x04, 0x00);
+          // set default sense if not set by callback
+          if ( p_msc->sense_key == 0 ) set_default_error_sense(lun);
         }
       }
     break;
@@ -691,13 +697,13 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
       {
         resplen = -1;
 
-        // If sense key is not set by callback, default to Logical Unit Not Ready, Cause Not Reportable
-        if ( p_msc->sense_key == 0 ) tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x04, 0x00);
+        // set default sense if not set by callback
+        if ( p_msc->sense_key == 0 ) set_default_error_sense(lun);
       }else
       {
         scsi_read_capacity10_resp_t read_capa10;
 
-        read_capa10.last_lba = tu_htonl(block_count-1);
+        read_capa10.last_lba  = tu_htonl(block_count-1);
         read_capa10.block_size = tu_htonl(block_size);
 
         resplen = sizeof(read_capa10);
@@ -727,8 +733,8 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
       {
         resplen = -1;
 
-        // If sense key is not set by callback, default to Logical Unit Not Ready, Cause Not Reportable
-        if ( p_msc->sense_key == 0 ) tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x04, 0x00);
+        // set default sense if not set by callback
+        if ( p_msc->sense_key == 0 ) set_default_error_sense(lun);
       }else
       {
         read_fmt_capa.block_num = tu_htonl(block_count);
@@ -765,10 +771,10 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
     {
       scsi_mode_sense6_resp_t mode_resp =
       {
-          .data_len = 3,
-          .medium_type = 0,
-          .write_protected = false,
-          .reserved = 0,
+          .data_len             = 3,
+          .medium_type          = 0,
+          .write_protected      = false,
+          .reserved             = 0,
           .block_descriptor_len = 0  // no block descriptor are included
       };
 
@@ -789,18 +795,23 @@ static int32_t proc_builtin_scsi(uint8_t lun, uint8_t const scsi_cmd[16], uint8_
     {
       scsi_sense_fixed_resp_t sense_rsp =
       {
-          .response_code = 0x70,
+          .response_code = 0x70, // current, fixed format
           .valid         = 1
       };
 
-      sense_rsp.add_sense_len = sizeof(scsi_sense_fixed_resp_t) - 8;
-
+      sense_rsp.add_sense_len       = sizeof(scsi_sense_fixed_resp_t) - 8;
       sense_rsp.sense_key           = p_msc->sense_key;
       sense_rsp.add_sense_code      = p_msc->add_sense_code;
       sense_rsp.add_sense_qualifier = p_msc->add_sense_qualifier;
 
       resplen = sizeof(sense_rsp);
       memcpy(buffer, &sense_rsp, resplen);
+
+      // request sense callback could overwrite the sense data
+      if (tud_msc_request_sense_cb)
+      {
+        resplen = tud_msc_request_sense_cb(lun, buffer, bufsize);
+      }
 
       // Clear sense data after copy
       tud_msc_set_sense(lun, 0, 0, 0);
@@ -835,8 +846,8 @@ static void proc_read10_cmd(uint8_t rhport, mscd_interface_t* p_msc)
     // negative means error -> endpoint is stalled & status in CSW set to failed
     TU_LOG(MSC_DEBUG, "  tud_msc_read10_cb() return -1\r\n");
 
-    // Sense = Flash not ready for access
-    tud_msc_set_sense(p_cbw->lun, SCSI_SENSE_MEDIUM_ERROR, 0x33, 0x00);
+    // set sense
+    set_default_error_sense(p_cbw->lun);
 
     fail_scsi_op(rhport, p_msc, MSC_CSW_STATUS_FAILED);
   }
@@ -900,8 +911,8 @@ static void proc_write10_new_data(uint8_t rhport, mscd_interface_t* p_msc, uint3
     // update actual byte before failed
     p_msc->xferred_len += xferred_bytes;
 
-    // Sense = Flash not ready for access
-    tud_msc_set_sense(p_cbw->lun, SCSI_SENSE_MEDIUM_ERROR, 0x33, 0x00);
+    // Set sense
+    set_default_error_sense(p_cbw->lun);
 
     fail_scsi_op(rhport, p_msc, MSC_CSW_STATUS_FAILED);
   }else

--- a/src/class/msc/msc_device.h
+++ b/src/class/msc/msc_device.h
@@ -131,6 +131,9 @@ TU_ATTR_WEAK uint8_t tud_msc_get_maxlun_cb(void);
 // - Start = 1 : active mode, if load_eject = 1 : load disk storage
 TU_ATTR_WEAK bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject);
 
+// Invoked when received REQUEST_SENSE
+TU_ATTR_WEAK int32_t tud_msc_request_sense_cb(uint8_t lun, void* buffer, uint16_t bufsize);
+
 // Invoked when Read10 command is complete
 TU_ATTR_WEAK void tud_msc_read10_complete_cb(uint8_t lun);
 

--- a/src/class/usbtmc/usbtmc_device.c
+++ b/src/class/usbtmc/usbtmc_device.c
@@ -235,17 +235,19 @@ void usbtmcd_init_cb(void)
   usbtmc_state.capabilities = tud_usbtmc_get_capabilities_cb();
 #ifndef NDEBUG
 # if CFG_TUD_USBTMC_ENABLE_488
-    if(usbtmc_state.capabilities->bmIntfcCapabilities488.supportsTrigger)
-      TU_ASSERT(&tud_usbtmc_msg_trigger_cb != NULL,);
-      // Per USB488 spec: table 8
-      TU_ASSERT(!usbtmc_state.capabilities->bmIntfcCapabilities.listenOnly,);
-      TU_ASSERT(!usbtmc_state.capabilities->bmIntfcCapabilities.talkOnly,);
+  if (usbtmc_state.capabilities->bmIntfcCapabilities488.supportsTrigger) {
+    TU_ASSERT(&tud_usbtmc_msg_trigger_cb != NULL,);
+  }
+  // Per USB488 spec: table 8
+  TU_ASSERT(!usbtmc_state.capabilities->bmIntfcCapabilities.listenOnly,);
+  TU_ASSERT(!usbtmc_state.capabilities->bmIntfcCapabilities.talkOnly,);
 # endif
-    if(usbtmc_state.capabilities->bmIntfcCapabilities.supportsIndicatorPulse)
-      TU_ASSERT(&tud_usbtmc_indicator_pulse_cb != NULL,);
+  if (usbtmc_state.capabilities->bmIntfcCapabilities.supportsIndicatorPulse) {
+    TU_ASSERT(&tud_usbtmc_indicator_pulse_cb != NULL,);
+  }
 #endif
 
-    usbtmcLock = osal_mutex_create(&usbtmcLockBuffer);
+  usbtmcLock = osal_mutex_create(&usbtmcLockBuffer);
 }
 
 uint16_t usbtmcd_open_cb(uint8_t rhport, tusb_desc_interface_t const * itf_desc, uint16_t max_len)

--- a/src/common/tusb_compiler.h
+++ b/src/common/tusb_compiler.h
@@ -137,9 +137,11 @@
   #define TU_BSWAP16(u16) (__builtin_bswap16(u16))
   #define TU_BSWAP32(u32) (__builtin_bswap32(u32))
 
+	#ifndef __ARMCC_VERSION
   // List of obsolete callback function that is renamed and should not be defined.
   // Put it here since only gcc support this pragma
-  #pragma GCC poison tud_vendor_control_request_cb
+		#pragma GCC poison tud_vendor_control_request_cb
+	#endif
 
 #elif defined(__TI_COMPILER_VERSION__)
   #define TU_ATTR_ALIGNED(Bytes)        __attribute__ ((aligned(Bytes)))

--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -37,31 +37,31 @@
  * manipulation that you are told to stay away.
  *
  * This contains macros for both VERIFY and ASSERT:
- * 
+ *
  *   VERIFY: Used when there is an error condition which is not the
  *           fault of the MCU. For example, bounds checking on data
  *           sent to the micro over USB should use this function.
  *           Another example is checking for buffer overflows, where
  *           returning from the active function causes a NAK.
- * 
+ *
  *   ASSERT: Used for error conditions that are caused by MCU firmware
  *           bugs. This is used to discover bugs in the code more
  *           quickly. One example would be adding assertions in library
  *           function calls to confirm a function's (untainted)
  *           parameters are valid.
- * 
+ *
  * The difference in behavior is that ASSERT triggers a breakpoint while
  * verify does not.
  *
  *   #define TU_VERIFY(cond)                  if(cond) return false;
  *   #define TU_VERIFY(cond,ret)              if(cond) return ret;
- *   
+ *
  *   #define TU_VERIFY_HDLR(cond,handler)     if(cond) {handler; return false;}
  *   #define TU_VERIFY_HDLR(cond,ret,handler) if(cond) {handler; return ret;}
  *
  *   #define TU_ASSERT(cond)                  if(cond) {_MESS_FAILED(); TU_BREAKPOINT(), return false;}
  *   #define TU_ASSERT(cond,ret)              if(cond) {_MESS_FAILED(); TU_BREAKPOINT(), return ret;}
- *  
+ *
  *------------------------------------------------------------------*/
 
 #ifdef __cplusplus
@@ -81,8 +81,8 @@
   #define _MESS_FAILED() do {} while (0)
 #endif
 
-// Halt CPU (breakpoint) when hitting error, only apply for Cortex M3, M4, M7
-#if defined(__ARM_ARCH_7M__) || defined (__ARM_ARCH_7EM__)
+// Halt CPU (breakpoint) when hitting error, only apply for Cortex M3, M4, M7, M33
+#if defined(__ARM_ARCH_7M__) || defined (__ARM_ARCH_7EM__) || defined(__ARM_ARCH_8M_MAIN__)
   #define TU_BREAKPOINT() do                                                                                \
   {                                                                                                         \
     volatile uint32_t* ARM_CM_DHCSR =  ((volatile uint32_t*) 0xE000EDF0UL); /* Cortex M CoreDebug->DHCSR */ \

--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -106,12 +106,12 @@ typedef struct TU_ATTR_ALIGNED(4)
 void dcd_init       (uint8_t rhport);
 
 // Interrupt Handler
-#if __GNUC__
+#if __GNUC__ && !defined(__ARMCC_VERSION)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wredundant-decls"
 #endif
 void dcd_int_handler(uint8_t rhport);
-#if __GNUC__
+#if __GNUC__ && !defined(__ARMCC_VERSION)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/device/dcd_attr.h
+++ b/src/device/dcd_attr.h
@@ -44,6 +44,7 @@
 
 #elif TU_CHECK_MCU(OPT_MCU_LPC18XX, OPT_MCU_LPC43XX)
   // TODO USB0 has 6, USB1 has 4
+  #define DCD_ATTR_CONTROLLER_CHIPIDEA_HS
   #define DCD_ATTR_ENDPOINT_MAX   6
 
 #elif TU_CHECK_MCU(OPT_MCU_LPC51UXX)
@@ -58,6 +59,7 @@
   #define DCD_ATTR_ENDPOINT_MAX   6
 
 #elif TU_CHECK_MCU(OPT_MCU_MIMXRT10XX)
+  #define DCD_ATTR_CONTROLLER_CHIPIDEA_HS
   #define DCD_ATTR_ENDPOINT_MAX   8
 
 #elif TU_CHECK_MCU(OPT_MCU_MKL25ZXX, OPT_MCU_K32L2BXX)
@@ -82,6 +84,10 @@
 
 #elif TU_CHECK_MCU(OPT_MCU_SAMX7X)
   #define DCD_ATTR_ENDPOINT_MAX   10
+  #define DCD_ATTR_ENDPOINT_EXCLUSIVE_NUMBER
+
+#elif TU_CHECK_MCU(OPT_MCU_PIC32MZ)
+  #define DCD_ATTR_ENDPOINT_MAX   8
   #define DCD_ATTR_ENDPOINT_EXCLUSIVE_NUMBER
 
 //------------- ST -------------//
@@ -188,12 +194,23 @@
   #define DCD_ATTR_ENDPOINT_MAX   4
 
 //------------- Broadcom -------------//
-#elif TU_CHECK_MCU(OPT_MCU_BCM2711)
+#elif TU_CHECK_MCU(OPT_MCU_BCM2711, OPT_MCU_BCM2835, OPT_MCU_BCM2837)
   #define DCD_ATTR_ENDPOINT_MAX   8
 
 //------------- Broadcom -------------//
 #elif TU_CHECK_MCU(OPT_MCU_XMC4000)
   #define DCD_ATTR_ENDPOINT_MAX   8
+
+//------------- BridgeTek -------------//
+#elif TU_CHECK_MCU(OPT_MCU_FT90X)
+  #define DCD_ATTR_ENDPOINT_MAX   8
+
+#elif TU_CHECK_MCU(OPT_MCU_FT93X)
+  #define DCD_ATTR_ENDPOINT_MAX   16
+
+//------------ Allwinner -------------//
+#elif TU_CHECK_MCU(OPT_MCU_F1C100S)
+  #define DCD_ATTR_ENDPOINT_MAX   4
 
 #else
   #warning "DCD_ATTR_ENDPOINT_MAX is not defined for this MCU, default to 8"

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -1008,7 +1008,7 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
         return tud_control_xfer(rhport, p_request, desc_device, sizeof(tusb_desc_device_t));
       }
     }
-    break;
+    // break; // unreachable
 
     case TUSB_DESC_BOS:
     {
@@ -1025,7 +1025,7 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
 
       return tud_control_xfer(rhport, p_request, (void*) desc_bos, total_len);
     }
-    break;
+    // break; // unreachable
 
     case TUSB_DESC_CONFIGURATION:
     case TUSB_DESC_OTHER_SPEED_CONFIG:
@@ -1051,7 +1051,7 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
 
       return tud_control_xfer(rhport, p_request, (void*) desc_config, total_len);
     }
-    break;
+    // break; // unreachable
 
     case TUSB_DESC_STRING:
     {
@@ -1064,7 +1064,7 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
       // first byte of descriptor is its size
       return tud_control_xfer(rhport, p_request, (void*) (uintptr_t) desc_str, tu_desc_len(desc_str));
     }
-    break;
+    // break; // unreachable
 
     case TUSB_DESC_DEVICE_QUALIFIER:
     {
@@ -1078,7 +1078,7 @@ static bool process_get_descriptor(uint8_t rhport, tusb_control_request_t const 
       // first byte of descriptor is its size
       return tud_control_xfer(rhport, p_request, (void*) (uintptr_t) desc_qualifier, tu_desc_len(desc_qualifier));
     }
-    break;
+    // break; // unreachable
 
     default: return false;
   }

--- a/src/osal/osal.h
+++ b/src/osal/osal.h
@@ -57,6 +57,8 @@ typedef void (*osal_task_func_t)( void * );
   #include "osal_pico.h"
 #elif CFG_TUSB_OS == OPT_OS_RTTHREAD
   #include "osal_rtthread.h"
+#elif CFG_TUSB_OS == OPT_OS_RTX4
+  #include "osal_rtx4.h"
 #elif CFG_TUSB_OS == OPT_OS_CUSTOM
   #include "tusb_os_custom.h" // implemented by application
 #else
@@ -67,7 +69,7 @@ typedef void (*osal_task_func_t)( void * );
 // OSAL Porting API
 //--------------------------------------------------------------------+
 
-#if __GNUC__
+#if __GNUC__ && !defined(__ARMCC_VERSION)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wredundant-decls"
 #endif
@@ -88,7 +90,7 @@ static inline osal_queue_t osal_queue_create(osal_queue_def_t* qdef);
 static inline bool osal_queue_receive(osal_queue_t qhdl, void* data);
 static inline bool osal_queue_send(osal_queue_t qhdl, void const * data, bool in_isr);
 static inline bool osal_queue_empty(osal_queue_t qhdl);
-#if __GNUC__
+#if __GNUC__ && !defined(__ARMCC_VERSION)
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/portable/chipidea/ci_hs/ci_hs_imxrt.h
+++ b/src/portable/chipidea/ci_hs/ci_hs_imxrt.h
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021, Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef _CI_HS_IMXRT_H_
+#define _CI_HS_IMXRT_H_
+
+#include "fsl_device_registers.h"
+
+static const ci_hs_controller_t _ci_controller[] =
+{
+  // RT1010 and RT1020 only has 1 USB controller
+  #if FSL_FEATURE_SOC_USBHS_COUNT == 1
+    { .reg_base = USB_BASE , .irqnum = USB_OTG1_IRQn, .ep_count = 8 }
+  #else
+    { .reg_base = USB1_BASE, .irqnum = USB_OTG1_IRQn, .ep_count = 8 },
+    { .reg_base = USB2_BASE, .irqnum = USB_OTG2_IRQn, .ep_count = 8 }
+  #endif
+};
+
+#define CI_DCD_INT_ENABLE(_p)   NVIC_EnableIRQ (_ci_controller[_p].irqnum)
+#define CI_DCD_INT_DISABLE(_p)  NVIC_DisableIRQ(_ci_controller[_p].irqnum)
+
+#define CI_HCD_INT_ENABLE(_p)   NVIC_EnableIRQ (_ci_controller[_p].irqnum)
+#define CI_HCD_INT_DISABLE(_p)  NVIC_DisableIRQ(_ci_controller[_p].irqnum)
+
+
+#endif

--- a/src/portable/chipidea/ci_hs/ci_hs_lpc18_43.h
+++ b/src/portable/chipidea/ci_hs/ci_hs_lpc18_43.h
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021, Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef _CI_HS_LPC18_43_H_
+#define _CI_HS_LPC18_43_H_
+
+// LPCOpen for 18xx & 43xx
+#include "chip.h"
+
+static const ci_hs_controller_t _ci_controller[] =
+{
+  { .reg_base = LPC_USB0_BASE, .irqnum = USB0_IRQn, .ep_count = 6 },
+  { .reg_base = LPC_USB1_BASE, .irqnum = USB1_IRQn, .ep_count = 4 }
+};
+
+#define CI_DCD_INT_ENABLE(_p)   NVIC_EnableIRQ (_ci_controller[_p].irqnum)
+#define CI_DCD_INT_DISABLE(_p)  NVIC_DisableIRQ(_ci_controller[_p].irqnum)
+
+#define CI_HCD_INT_ENABLE(_p)   NVIC_EnableIRQ (_ci_controller[_p].irqnum)
+#define CI_HCD_INT_DISABLE(_p)  NVIC_DisableIRQ(_ci_controller[_p].irqnum)
+
+#endif

--- a/src/portable/chipidea/ci_hs/ci_hs_type.h
+++ b/src/portable/chipidea/ci_hs/ci_hs_type.h
@@ -24,8 +24,8 @@
  * This file is part of the TinyUSB stack.
  */
 
-#ifndef COMMON_TRANSDIMENSION_H_
-#define COMMON_TRANSDIMENSION_H_
+#ifndef CI_HS_TYPE_H_
+#define CI_HS_TYPE_H_
 
 #ifdef __cplusplus
  extern "C" {
@@ -85,52 +85,60 @@ enum {
 typedef struct
 {
   //------------- ID + HW Parameter Registers-------------//
-  __I  uint32_t TU_RESERVED[64]; ///< For iMX RT10xx, but not used by LPC18XX/LPC43XX
+  volatile uint32_t TU_RESERVED[64]; ///< For iMX RT10xx, but not used by LPC18XX/LPC43XX
 
   //------------- Capability Registers-------------//
-  __I  uint8_t  CAPLENGTH;       ///< Capability Registers Length
-  __I  uint8_t  TU_RESERVED[1];
-  __I  uint16_t HCIVERSION;      ///< Host Controller Interface Version
+  volatile uint8_t  CAPLENGTH;       ///< Capability Registers Length
+  volatile uint8_t  TU_RESERVED[1];
+  volatile uint16_t HCIVERSION;      ///< Host Controller Interface Version
 
-  __I  uint32_t HCSPARAMS;       ///< Host Controller Structural Parameters
-  __I  uint32_t HCCPARAMS;       ///< Host Controller Capability Parameters
-  __I  uint32_t TU_RESERVED[5];
+  volatile uint32_t HCSPARAMS;       ///< Host Controller Structural Parameters
+  volatile uint32_t HCCPARAMS;       ///< Host Controller Capability Parameters
+  volatile uint32_t TU_RESERVED[5];
 
-  __I  uint16_t DCIVERSION;      ///< Device Controller Interface Version
-  __I  uint8_t  TU_RESERVED[2];
+  volatile uint16_t DCIVERSION;      ///< Device Controller Interface Version
+  volatile uint8_t  TU_RESERVED[2];
 
-  __I  uint32_t DCCPARAMS;       ///< Device Controller Capability Parameters
-  __I  uint32_t TU_RESERVED[6];
+  volatile uint32_t DCCPARAMS;       ///< Device Controller Capability Parameters
+  volatile uint32_t TU_RESERVED[6];
 
   //------------- Operational Registers -------------//
-  __IO uint32_t USBCMD;          ///< USB Command Register
-  __IO uint32_t USBSTS;          ///< USB Status Register
-  __IO uint32_t USBINTR;         ///< Interrupt Enable Register
-  __IO uint32_t FRINDEX;         ///< USB Frame Index
-  __I  uint32_t TU_RESERVED;
-  __IO uint32_t DEVICEADDR;      ///< Device Address
-  __IO uint32_t ENDPTLISTADDR;   ///< Endpoint List Address
-  __I  uint32_t TU_RESERVED;
-  __IO uint32_t BURSTSIZE;       ///< Programmable Burst Size
-  __IO uint32_t TXFILLTUNING;    ///< TX FIFO Fill Tuning
-       uint32_t TU_RESERVED[4];
-  __IO uint32_t ENDPTNAK;        ///< Endpoint NAK
-  __IO uint32_t ENDPTNAKEN;      ///< Endpoint NAK Enable
-  __I  uint32_t TU_RESERVED;
-  __IO uint32_t PORTSC1;         ///< Port Status & Control
-  __I  uint32_t TU_RESERVED[7];
-  __IO uint32_t OTGSC;           ///< On-The-Go Status & control
-  __IO uint32_t USBMODE;         ///< USB Device Mode
-  __IO uint32_t ENDPTSETUPSTAT;  ///< Endpoint Setup Status
-  __IO uint32_t ENDPTPRIME;      ///< Endpoint Prime
-  __IO uint32_t ENDPTFLUSH;      ///< Endpoint Flush
-  __I  uint32_t ENDPTSTAT;       ///< Endpoint Status
-  __IO uint32_t ENDPTCOMPLETE;   ///< Endpoint Complete
-  __IO uint32_t ENDPTCTRL[8];    ///< Endpoint Control 0 - 7
-} dcd_registers_t, hcd_registers_t;
+  volatile uint32_t USBCMD;          ///< USB Command Register
+  volatile uint32_t USBSTS;          ///< USB Status Register
+  volatile uint32_t USBINTR;         ///< Interrupt Enable Register
+  volatile uint32_t FRINDEX;         ///< USB Frame Index
+  volatile uint32_t TU_RESERVED;
+  volatile uint32_t DEVICEADDR;      ///< Device Address
+  volatile uint32_t ENDPTLISTADDR;   ///< Endpoint List Address
+  volatile uint32_t TU_RESERVED;
+  volatile uint32_t BURSTSIZE;       ///< Programmable Burst Size
+  volatile uint32_t TXFILLTUNING;    ///< TX FIFO Fill Tuning
+           uint32_t TU_RESERVED[4];
+  volatile uint32_t ENDPTNAK;        ///< Endpoint NAK
+  volatile uint32_t ENDPTNAKEN;      ///< Endpoint NAK Enable
+  volatile uint32_t TU_RESERVED;
+  volatile uint32_t PORTSC1;         ///< Port Status & Control
+  volatile uint32_t TU_RESERVED[7];
+  volatile uint32_t OTGSC;           ///< On-The-Go Status & control
+  volatile uint32_t USBMODE;         ///< USB Device Mode
+  volatile uint32_t ENDPTSETUPSTAT;  ///< Endpoint Setup Status
+  volatile uint32_t ENDPTPRIME;      ///< Endpoint Prime
+  volatile uint32_t ENDPTFLUSH;      ///< Endpoint Flush
+  volatile uint32_t ENDPTSTAT;       ///< Endpoint Status
+  volatile uint32_t ENDPTCOMPLETE;   ///< Endpoint Complete
+  volatile uint32_t ENDPTCTRL[8];    ///< Endpoint Control 0 - 7
+} ci_hs_regs_t;
+
+
+typedef struct
+{
+  uint32_t reg_base;
+  uint32_t irqnum;
+  uint8_t  ep_count; // Max bi-directional Endpoints
+}ci_hs_controller_t;
 
 #ifdef __cplusplus
  }
 #endif
 
-#endif /* COMMON_TRANSDIMENSION_H_ */
+#endif /* CI_HS_TYPE_H_ */

--- a/src/portable/chipidea/ci_hs/dcd_ci_hs.c
+++ b/src/portable/chipidea/ci_hs/dcd_ci_hs.c
@@ -25,24 +25,29 @@
  */
 
 #include "tusb_option.h"
+#include "device/dcd_attr.h"
 
-#if TUSB_OPT_DEVICE_ENABLED && \
-    (CFG_TUSB_MCU == OPT_MCU_LPC18XX || CFG_TUSB_MCU == OPT_MCU_LPC43XX || CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX)
+#if TUSB_OPT_DEVICE_ENABLED && defined(DCD_ATTR_CONTROLLER_CHIPIDEA_HS)
 
 //--------------------------------------------------------------------+
 // INCLUDE
 //--------------------------------------------------------------------+
+#include "device/dcd.h"
+#include "ci_hs_type.h"
+
 #if CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX
-  #include "fsl_device_registers.h"
-  #define INCLUDE_FSL_DEVICE_REGISTERS
+  #include "ci_hs_imxrt.h"
+#elif TU_CHECK_MCU(OPT_MCU_LPC18XX, OPT_MCU_LPC43XX)
+  #include "ci_hs_lpc18_43.h"
 #else
-  // LPCOpen for 18xx & 43xx
-  #include "chip.h"
+  #error "Unsupported MCUs"
 #endif
 
-#include "common/tusb_common.h"
-#include "device/dcd.h"
-#include "common_transdimension.h"
+//--------------------------------------------------------------------+
+// MACRO CONSTANT TYPEDEF
+//--------------------------------------------------------------------+
+
+#define CI_HS_REG(_port)      ((ci_hs_regs_t*) _ci_controller[_port].reg_base)
 
 #if defined(__CORTEX_M) && __CORTEX_M == 7 && __DCACHE_PRESENT == 1
   #define CleanInvalidateDCache_by_Addr   SCB_CleanInvalidateDCache_by_Addr
@@ -50,9 +55,6 @@
   #define CleanInvalidateDCache_by_Addr(_addr, _dsize)
 #endif
 
-//--------------------------------------------------------------------+
-// MACRO CONSTANT TYPEDEF
-//--------------------------------------------------------------------+
 
 // ENDPTCTRL
 enum {
@@ -144,33 +146,6 @@ TU_VERIFY_STATIC( sizeof(dcd_qhd_t) == 64, "size is not correct");
 // Variables
 //--------------------------------------------------------------------+
 
-typedef struct
-{
-  dcd_registers_t* regs;  // registers
-  const IRQn_Type irqnum; // IRQ number
-  const uint8_t ep_count; // Max bi-directional Endpoints
-}dcd_controller_t;
-
-#if CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX
-  static const dcd_controller_t _dcd_controller[] =
-  {
-    // RT1010 and RT1020 only has 1 USB controller
-    #if FSL_FEATURE_SOC_USBHS_COUNT == 1
-      { .regs = (dcd_registers_t*) USB_BASE , .irqnum = USB_OTG1_IRQn, .ep_count = 8 }
-    #else
-      { .regs = (dcd_registers_t*) USB1_BASE, .irqnum = USB_OTG1_IRQn, .ep_count = 8 },
-      { .regs = (dcd_registers_t*) USB2_BASE, .irqnum = USB_OTG2_IRQn, .ep_count = 8 }
-    #endif
-  };
-
-#else
-  static const dcd_controller_t _dcd_controller[] =
-  {
-    { .regs = (dcd_registers_t*) LPC_USB0_BASE, .irqnum = USB0_IRQn, .ep_count = 6 },
-    { .regs = (dcd_registers_t*) LPC_USB1_BASE, .irqnum = USB1_IRQn, .ep_count = 4 }
-  };
-#endif
-
 #define QTD_NEXT_INVALID 0x01
 
 typedef struct {
@@ -191,14 +166,14 @@ static dcd_data_t _dcd_data;
 /// follows LPC43xx User Manual 23.10.3
 static void bus_reset(uint8_t rhport)
 {
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
 
   // The reset value for all endpoint types is the control endpoint. If one endpoint
   // direction is enabled and the paired endpoint of opposite direction is disabled, then the
   // endpoint type of the unused direction must be changed from the control type to any other
   // type (e.g. bulk). Leaving an un-configured endpoint control will cause undefined behavior
   // for the data PID tracking on the active endpoint.
-  for( uint8_t i=1; i < _dcd_controller[rhport].ep_count; i++)
+  for( uint8_t i=1; i < _ci_controller[rhport].ep_count; i++)
   {
     dcd_reg->ENDPTCTRL[i] = (TUSB_XFER_BULK << ENDPTCTRL_TYPE_POS) | (TUSB_XFER_BULK << (16+ENDPTCTRL_TYPE_POS));
   }
@@ -231,7 +206,7 @@ void dcd_init(uint8_t rhport)
 {
   tu_memclr(&_dcd_data, sizeof(dcd_data_t));
 
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
 
   // Reset controller
   dcd_reg->USBCMD |= USBCMD_RESET;
@@ -257,12 +232,12 @@ void dcd_init(uint8_t rhport)
 
 void dcd_int_enable(uint8_t rhport)
 {
-  NVIC_EnableIRQ(_dcd_controller[rhport].irqnum);
+  CI_DCD_INT_ENABLE(rhport);
 }
 
 void dcd_int_disable(uint8_t rhport)
 {
-  NVIC_DisableIRQ(_dcd_controller[rhport].irqnum);
+  CI_DCD_INT_DISABLE(rhport);
 }
 
 void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
@@ -270,25 +245,25 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
   // Response with status first before changing device address
   dcd_edpt_xfer(rhport, tu_edpt_addr(0, TUSB_DIR_IN), NULL, 0);
 
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
   dcd_reg->DEVICEADDR = (dev_addr << 25) | TU_BIT(24);
 }
 
 void dcd_remote_wakeup(uint8_t rhport)
 {
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
   dcd_reg->PORTSC1 |= PORTSC1_FORCE_PORT_RESUME;
 }
 
 void dcd_connect(uint8_t rhport)
 {
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
   dcd_reg->USBCMD |= USBCMD_RUN_STOP;
 }
 
 void dcd_disconnect(uint8_t rhport)
 {
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
   dcd_reg->USBCMD &= ~USBCMD_RUN_STOP;
 }
 
@@ -334,7 +309,7 @@ void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr)
   uint8_t const epnum  = tu_edpt_number(ep_addr);
   uint8_t const dir    = tu_edpt_dir(ep_addr);
 
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
   dcd_reg->ENDPTCTRL[epnum] |= ENDPTCTRL_STALL << (dir ? 16 : 0);
 
   // flush to abort any primed buffer
@@ -347,7 +322,7 @@ void dcd_edpt_clear_stall(uint8_t rhport, uint8_t ep_addr)
   uint8_t const dir   = tu_edpt_dir(ep_addr);
 
   // data toggle also need to be reset
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
   dcd_reg->ENDPTCTRL[epnum] |= ENDPTCTRL_TOGGLE_RESET << ( dir ? 16 : 0 );
   dcd_reg->ENDPTCTRL[epnum] &= ~(ENDPTCTRL_STALL << ( dir  ? 16 : 0));
 }
@@ -358,7 +333,7 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc)
   uint8_t const dir   = tu_edpt_dir(p_endpoint_desc->bEndpointAddress);
 
   // Must not exceed max endpoint number
-  TU_ASSERT( epnum < _dcd_controller[rhport].ep_count );
+  TU_ASSERT( epnum < _ci_controller[rhport].ep_count );
 
   //------------- Prepare Queue Head -------------//
   dcd_qhd_t * p_qhd = &_dcd_data.qhd[epnum][dir];
@@ -376,7 +351,7 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc)
   CleanInvalidateDCache_by_Addr((uint32_t*) &_dcd_data, sizeof(dcd_data_t));
 
   // Enable EP Control
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
 
   uint32_t const epctrl = (p_endpoint_desc->bmAttributes.xfer << ENDPTCTRL_TYPE_POS) | ENDPTCTRL_ENABLE | ENDPTCTRL_TOGGLE_RESET;
 
@@ -393,10 +368,10 @@ bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc)
 
 void dcd_edpt_close_all (uint8_t rhport)
 {
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
 
   // Disable all non-control endpoints
-  for( uint8_t epnum=1; epnum < _dcd_controller[rhport].ep_count; epnum++)
+  for( uint8_t epnum=1; epnum < _ci_controller[rhport].ep_count; epnum++)
   {
     _dcd_data.qhd[epnum][TUSB_DIR_OUT].qtd_overlay.halted = 1;
     _dcd_data.qhd[epnum][TUSB_DIR_IN ].qtd_overlay.halted = 1;
@@ -411,7 +386,7 @@ void dcd_edpt_close(uint8_t rhport, uint8_t ep_addr)
   uint8_t const epnum  = tu_edpt_number(ep_addr);
   uint8_t const dir    = tu_edpt_dir(ep_addr);
 
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
 
   _dcd_data.qhd[epnum][dir].qtd_overlay.halted = 1;
 
@@ -426,7 +401,7 @@ void dcd_edpt_close(uint8_t rhport, uint8_t ep_addr)
 
 static void qhd_start_xfer(uint8_t rhport, uint8_t epnum, uint8_t dir)
 {
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
   dcd_qhd_t* p_qhd = &_dcd_data.qhd[epnum][dir];
   dcd_qtd_t* p_qtd = &_dcd_data.qtd[epnum][dir];
 
@@ -542,7 +517,7 @@ static void process_edpt_complete_isr(uint8_t rhport, uint8_t epnum, uint8_t dir
 
   if ( result != XFER_RESULT_SUCCESS )
   {
-    dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+    ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
     // flush to abort error buffer
     dcd_reg->ENDPTFLUSH = TU_BIT(epnum + (dir ? 16 : 0));
   }
@@ -566,7 +541,7 @@ static void process_edpt_complete_isr(uint8_t rhport, uint8_t epnum, uint8_t dir
 
 void dcd_int_handler(uint8_t rhport)
 {
-  dcd_registers_t* dcd_reg = _dcd_controller[rhport].regs;
+  ci_hs_regs_t* dcd_reg = CI_HS_REG(rhport);
 
   uint32_t const int_enable = dcd_reg->USBINTR;
   uint32_t const int_status = dcd_reg->USBSTS & int_enable;

--- a/src/portable/chipidea/ci_hs/hcd_ci_hs.c
+++ b/src/portable/chipidea/ci_hs/hcd_ci_hs.c
@@ -1,0 +1,93 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "tusb_option.h"
+
+// Chipidea Highspeed USB IP implement EHCI for host functionality
+
+#if TUSB_OPT_HOST_ENABLED && \
+    (CFG_TUSB_MCU == OPT_MCU_LPC18XX || CFG_TUSB_MCU == OPT_MCU_LPC43XX || CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX)
+
+//--------------------------------------------------------------------+
+// INCLUDE
+//--------------------------------------------------------------------+
+#include "common/tusb_common.h"
+#include "portable/ehci/ehci_api.h"
+#include "ci_hs_type.h"
+
+#if CFG_TUSB_MCU == OPT_MCU_MIMXRT10XX
+  #include "ci_hs_imxrt.h"
+#elif TU_CHECK_MCU(OPT_MCU_LPC18XX, OPT_MCU_LPC43XX)
+  #include "ci_hs_lpc18_43.h"
+#else
+  #error "Unsupported MCUs"
+#endif
+
+//--------------------------------------------------------------------+
+// MACRO CONSTANT TYPEDEF
+//--------------------------------------------------------------------+
+
+#define CI_HS_REG(_port)      ((ci_hs_regs_t*) _ci_controller[_port].reg_base)
+
+//--------------------------------------------------------------------+
+// Controller API
+//--------------------------------------------------------------------+
+
+bool hcd_init(uint8_t rhport)
+{
+  ci_hs_regs_t* hcd_reg = CI_HS_REG(rhport);
+
+  // Reset controller
+  hcd_reg->USBCMD |= USBCMD_RESET;
+  while( hcd_reg->USBCMD & USBCMD_RESET ) {}
+
+  // Set mode to device, must be set immediately after reset
+#if CFG_TUSB_MCU == OPT_MCU_LPC18XX || CFG_TUSB_MCU == OPT_MCU_LPC43XX
+  // LPC18XX/43XX need to set VBUS Power Select to HIGH
+  // RHPORT1 is fullspeed only (need external PHY for Highspeed)
+  hcd_reg->USBMODE = USBMODE_CM_HOST | USBMODE_VBUS_POWER_SELECT;
+  if (rhport == 1) hcd_reg->PORTSC1 |= PORTSC1_FORCE_FULL_SPEED;
+#else
+  hcd_reg->USBMODE = USBMODE_CM_HOST;
+#endif
+
+  // FIXME force full speed, still have issue with Highspeed enumeration
+  hcd_reg->PORTSC1 |= PORTSC1_FORCE_FULL_SPEED;
+
+  return ehci_init(rhport, (uint32_t) &hcd_reg->CAPLENGTH, (uint32_t) &hcd_reg->USBCMD);
+}
+
+void hcd_int_enable(uint8_t rhport)
+{
+  CI_HCD_INT_ENABLE(rhport);
+}
+
+void hcd_int_disable(uint8_t rhport)
+{
+  CI_HCD_INT_DISABLE(rhport);
+}
+
+#endif

--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -38,6 +38,10 @@
 #include "device/usbd.h"
 #include "device/usbd_pvt.h" // to use defer function helper
 
+#if CFG_TUSB_OS == OPT_OS_MYNEWT
+#include "mcu/mcu.h"
+#endif
+
 /*------------------------------------------------------------------*/
 /* MACRO TYPEDEF CONSTANT ENUM
  *------------------------------------------------------------------*/
@@ -453,9 +457,11 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
 
   xfer_td_t* xfer = get_td(epnum, dir);
 
+  dcd_int_disable(rhport);
   xfer->buffer     = buffer;
   xfer->total_len  = total_bytes;
   xfer->actual_len = 0;
+  dcd_int_enable(rhport);
 
   // Control endpoint with zero-length packet and opposite direction to 1st request byte --> status stage
   bool const control_status = (epnum == 0 && total_bytes == 0 && dir != tu_edpt_dir(NRF_USBD->BMREQUESTTYPE));
@@ -476,7 +482,7 @@ bool dcd_edpt_xfer (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t 
       edpt_dma_start(&NRF_USBD->TASKS_EP0RCVOUT);
     }else
     {
-      if ( xfer->data_received )
+      if ( xfer->data_received && xfer->total_len > xfer->actual_len)
       {
         // Data is already received previously
         // start DMA to copy to SRAM
@@ -891,6 +897,11 @@ static bool hfclk_running(void)
 
 static void hfclk_enable(void)
 {
+#if CFG_TUSB_OS == OPT_OS_MYNEWT
+  usb_clock_request();
+  return;
+#else
+
   // already running, nothing to do
   if ( hfclk_running() ) return;
 
@@ -904,10 +915,16 @@ static void hfclk_enable(void)
 
   nrf_clock_event_clear(NRF_CLOCK, NRF_CLOCK_EVENT_HFCLKSTARTED);
   nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTART);
+#endif
 }
 
 static void hfclk_disable(void)
 {
+#if CFG_TUSB_OS == OPT_OS_MYNEWT
+  usb_clock_release();
+  return;
+#else
+
 #ifdef SOFTDEVICE_PRESENT
   if ( is_sd_enabled() )
   {
@@ -917,6 +934,7 @@ static void hfclk_disable(void)
 #endif
 
   nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_HFCLKSTOP);
+#endif
 }
 
 // Power & Clock Peripheral on nRF5x to manage USB
@@ -1059,7 +1077,13 @@ void tusb_hal_nrf_power_event (uint32_t event)
 
       // Enable interrupt, priorities should be set by application
       NVIC_ClearPendingIRQ(USBD_IRQn);
-      NVIC_EnableIRQ(USBD_IRQn);
+      // Don't enable USBD interrupt yet, if dcd_init() did not finish yet
+      // Interrupt will be enabled by tud_init(), when USB stack is ready
+      // to handle interrupts.
+      if (tud_inited())
+      {
+        NVIC_EnableIRQ(USBD_IRQn);
+      }
 
       // Wait for HFCLK
       while ( !hfclk_running() ) { }

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -412,10 +412,28 @@ tusb_speed_t hcd_port_speed_get(uint8_t rhport)
 // Close all opened endpoint belong to this device
 void hcd_device_close(uint8_t rhport, uint8_t dev_addr)
 {
-    (void) rhport;
-    (void) dev_addr;
+  pico_trace("hcd_device_close %d\n", dev_addr);
+  (void) rhport;
 
-    pico_trace("hcd_device_close %d\n", dev_addr);
+  if (dev_addr == 0) return;
+
+  for (size_t i = 1; i < TU_ARRAY_SIZE(ep_pool); i++)
+  {
+    hw_endpoint_t* ep = &ep_pool[i];
+
+    if (ep->dev_addr == dev_addr && ep->configured)
+    {
+      // in case it is an interrupt endpoint, disable it
+      usb_hw_clear->int_ep_ctrl = (1 << (ep->interrupt_num + 1));
+      usb_hw->int_ep_addr_ctrl[ep->interrupt_num] = 0;
+
+      // unconfigure the endpoint
+      ep->configured = false;
+      *ep->endpoint_control = 0;
+      *ep->buffer_control = 0;
+      hw_endpoint_reset_transfer(ep);
+    }
+  }
 }
 
 uint32_t hcd_frame_number(uint8_t rhport)

--- a/src/portable/raspberrypi/rp2040/rp2040_usb.c
+++ b/src/portable/raspberrypi/rp2040/rp2040_usb.c
@@ -294,7 +294,7 @@ bool hw_endpoint_xfer_continue(struct hw_endpoint *ep)
   // Part way through a transfer
   if (!ep->active)
   {
-    panic("Can't continue xfer on inactive ep %d %s", tu_edpt_number(ep->ep_addr), ep_dir_string);
+    panic("Can't continue xfer on inactive ep %d %s", tu_edpt_number(ep->ep_addr), ep_dir_string[tu_edpt_dir(ep->ep_addr)]);
   }
 
   // Update EP struct from hardware state

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -132,9 +132,21 @@
 
 // Broadcom
 #define OPT_MCU_BCM2711          1700 ///< Broadcom BCM2711
+#define OPT_MCU_BCM2835          1701 ///< Broadcom BCM2835
+#define OPT_MCU_BCM2837          1702 ///< Broadcom BCM2837
 
 // Infineon
 #define OPT_MCU_XMC4000          1800 ///< Infineon XMC4000
+
+// PIC
+#define OPT_MCU_PIC32MZ          1900 ///< MicroChip PIC32MZ family
+
+// BridgeTek
+#define OPT_MCU_FT90X            2000 ///< BridgeTek FT90x
+#define OPT_MCU_FT93X            2001 ///< BridgeTek FT93x
+
+// Allwinner
+#define OPT_MCU_F1C100S          2100 ///< Allwinner F1C100s family
 
 // Helper to check if configured MCU is one of listed
 // Apply _TU_CHECK_MCU with || as separator to list of input
@@ -151,6 +163,7 @@
 #define OPT_OS_CUSTOM     4  ///< Custom OS is implemented by application
 #define OPT_OS_PICO       5  ///< Raspberry Pi Pico SDK
 #define OPT_OS_RTTHREAD   6  ///< RT-Thread
+#define OPT_OS_RTX4       7  ///< Keil RTX 4
 
 // Allow to use command line to change the config name/location
 #ifdef CFG_TUSB_CONFIG_FILE


### PR DESCRIPTION

- update tinyusb to https://github.com/hathach/tinyusb/commit/fcca8bb4ca219b2b43169997a5a00d65bc12c877
- response with illegal request to SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL, required for macos for "sdcard reader" application
- update `msc_external_flash_sdcard.ino` example to work with dynamic sd card removal for board that support SD Detection pin e.g PyPortal.

@dhalbert [examples/MassStorage/msc_external_flash_sdcard/msc_external_flash_sdcard.ino](https://github.com/adafruit/Adafruit_TinyUSB_Arduino/compare/msc-unit-ready?expand=1#diff-14ab6efd157f9212ace26549d297d7faa5a302e8ce60951645c27176bcd41be0) is the one that generates the test uf2