### PR TITLE
Enable library for Arduino SAMD based on USBCON

### DIFF
--- a/src/Adafruit_TinyUSB.h
+++ b/src/Adafruit_TinyUSB.h
@@ -26,8 +26,8 @@
 #define ADAFRUIT_TINYUSB_H_
 
 // Error message for Core that must select TinyUSB via menu
-#if !defined(USE_TINYUSB) && ( defined(ARDUINO_ARCH_SAMD) || \
-                               (defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED)) )
+#if !defined(USE_TINYUSB) && ((defined(ARDUINO_ARCH_SAMD) && defined(ARDUINO_SAMD_ADAFRUIT)) || \
+                              (defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED)))
 #error TinyUSB is not selected, please select it in "Tools->Menu->USB Stack"
 #endif
 

--- a/src/arduino/ports/esp32/Adafruit_TinyUSB_esp32.cpp
+++ b/src/arduino/ports/esp32/Adafruit_TinyUSB_esp32.cpp
@@ -183,4 +183,4 @@ extern "C" void yield(void) {
 }
 #endif // commented out
 
-#endif
+#endif // defined(ARDUINO_ARCH_ESP32) && TUSB_OPT_DEVICE_ENABLED

--- a/src/arduino/ports/nrf/Adafruit_TinyUSB_nrf.cpp
+++ b/src/arduino/ports/nrf/Adafruit_TinyUSB_nrf.cpp
@@ -24,7 +24,7 @@
 
 #include "tusb_option.h"
 
-#if defined ARDUINO_NRF52_ADAFRUIT && TUSB_OPT_DEVICE_ENABLED
+#if defined(ARDUINO_NRF52_ADAFRUIT) && TUSB_OPT_DEVICE_ENABLED
 
 #include "nrfx.h"
 #include "nrfx_power.h"
@@ -134,4 +134,4 @@ static void usb_hardware_init(void) {
   }
 }
 
-#endif // USE_TINYUSB
+#endif // defined(ARDUINO_NRF52_ADAFRUIT) && TUSB_OPT_DEVICE_ENABLED

--- a/src/arduino/ports/nrf/tusb_config_nrf.h
+++ b/src/arduino/ports/nrf/tusb_config_nrf.h
@@ -34,7 +34,7 @@ extern "C" {
 //--------------------------------------------------------------------
 #define CFG_TUSB_MCU OPT_MCU_NRF5X
 
-#ifdef USE_TINYUSB
+#ifdef USE_TINYUSB || !defined(USBCON)
 #define CFG_TUSB_RHPORT0_MODE OPT_MODE_DEVICE
 #else
 #define CFG_TUSB_RHPORT0_MODE OPT_MODE_NONE

--- a/src/arduino/ports/rp2040/Adafruit_TinyUSB_rp2040.cpp
+++ b/src/arduino/ports/rp2040/Adafruit_TinyUSB_rp2040.cpp
@@ -24,7 +24,7 @@
 
 #include "tusb_option.h"
 
-#if defined ARDUINO_ARCH_RP2040 && TUSB_OPT_DEVICE_ENABLED
+#if defined(ARDUINO_ARCH_RP2040) && TUSB_OPT_DEVICE_ENABLED
 
 #include "Arduino.h"
 
@@ -151,4 +151,4 @@ void TinyUSB_Device_Task(void) {
 }
 }
 
-#endif
+#endif // defined(ARDUINO_ARCH_RP2040) && TUSB_OPT_DEVICE_ENABLED

--- a/src/arduino/ports/samd/Adafruit_TinyUSB_samd.cpp
+++ b/src/arduino/ports/samd/Adafruit_TinyUSB_samd.cpp
@@ -24,7 +24,7 @@
 
 #include "tusb_option.h"
 
-#if defined ARDUINO_ARCH_SAMD && TUSB_OPT_DEVICE_ENABLED
+#if defined(ARDUINO_ARCH_SAMD) && TUSB_OPT_DEVICE_ENABLED
 
 #include "Arduino.h"
 #include <Reset.h> // Needed for auto-reset with 1200bps port touch
@@ -156,4 +156,4 @@ uint8_t TinyUSB_Port_GetSerialNumber(uint8_t serial_id[16]) {
   return 16;
 }
 
-#endif
+#endif //  defined(ARDUINO_ARCH_SAMD) && TUSB_OPT_DEVICE_ENABLED

--- a/src/arduino/ports/samd/tusb_config_samd.h
+++ b/src/arduino/ports/samd/tusb_config_samd.h
@@ -38,7 +38,7 @@ extern "C" {
 #define CFG_TUSB_MCU OPT_MCU_SAMD21
 #endif
 
-#ifdef USE_TINYUSB
+#if defined(USE_TINYUSB) || !defined(USBCON)
 #define CFG_TUSB_RHPORT0_MODE OPT_MODE_DEVICE
 #else
 #define CFG_TUSB_RHPORT0_MODE OPT_MODE_NONE


### PR DESCRIPTION
TinyUSB can be used without explicitly defining USE_TINYUSB. This is useful for cores without built-in support for the define.

Related PR: arduino/ArduinoCore-samd#668