### PR TITLE
added example support for Arduino Nano RP2040 Connect

### DIFF
--- a/docs/examples/webusb-rgb/serial.js
+++ b/docs/examples/webusb-rgb/serial.js
@@ -13,6 +13,7 @@ var serial = {};
     const filters = [
       { 'vendorId': 0x239A }, // Adafruit boards
       { 'vendorId': 0xcafe }, // TinyUSB example
+      { 'vendorId': 0x2341 }, // Arduino Nano RP2040 Connect
     ];
     return navigator.usb.requestDevice({ 'filters': filters }).then(
       device => new serial.Port(device)

--- a/docs/examples/webusb-serial/serial.js
+++ b/docs/examples/webusb-serial/serial.js
@@ -13,6 +13,7 @@ var serial = {};
     const filters = [
       { 'vendorId': 0x239A }, // Adafruit boards
       { 'vendorId': 0xcafe }, // TinyUSB example
+      { 'vendorId': 0x2341 }, // Arduino Nano RP2040 Connect
     ];
     return navigator.usb.requestDevice({ 'filters': filters }).then(
       device => new serial.Port(device)

--- a/examples/WebUSB/webusb_rgb/webusb_rgb.ino
+++ b/examples/WebUSB/webusb_rgb/webusb_rgb.ino
@@ -55,6 +55,10 @@ WEBUSB_URL_DEF(landingPage, 1 /*https*/, "adafruit.github.io/Adafruit_TinyUSB_Ar
 // the setup function runs once when you press reset or power the board
 void setup()
 {
+#if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
+  // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
+  TinyUSB_Device_Init(0);
+#endif
   //usb_web.setStringDescriptor("TinyUSB WebUSB");
   usb_web.setLandingPage(&landingPage);
   usb_web.setLineStateCallback(line_state_callback);


### PR DESCRIPTION
I noticed that one onf the WebUSB examples was not compatible with the Arduino Nano rp2040.
And while I was working on that I also added the vendorId to the browser examples.