### PR TITLE
Added setStartStopCallback

### DIFF
--- a/src/arduino/msc/Adafruit_USBD_MSC.cpp
+++ b/src/arduino/msc/Adafruit_USBD_MSC.cpp
@@ -108,6 +108,10 @@ void Adafruit_USBD_MSC::setReadWriteCallback(uint8_t lun, read_callback_t rd_cb,
   _lun_info[lun].fl_cb = fl_cb;
 }
 
+void Adafruit_USBD_MSC::setStartStopCallback(uint8_t lun, start_stop_callback_t cb) {
+  _lun_info[lun].start_stop_cb = cb;
+}
+
 void Adafruit_USBD_MSC::setReadyCallback(uint8_t lun, ready_callback_t cb) {
   _lun_info[lun].ready_cb = cb;
 }
@@ -225,6 +229,16 @@ int32_t tud_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16], void *buffer,
   }
 
   return resplen;
+}
+
+// Callback invoked on start/stop
+bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject)
+{
+  if (!(_msc_dev && _msc_dev->_lun_info[lun].start_stop_cb)) {
+    return true;
+  }
+
+  return _msc_dev->_lun_info[lun].start_stop_cb(power_condition, start, load_eject);
 }
 
 // Callback invoked when received READ10 command.

--- a/src/arduino/msc/Adafruit_USBD_MSC.h
+++ b/src/arduino/msc/Adafruit_USBD_MSC.h
@@ -36,6 +36,7 @@ public:
   typedef void (*flush_callback_t)(void);
   typedef bool (*ready_callback_t)(void);
   typedef bool (*writable_callback_t)(void);
+  typedef bool (*start_stop_callback_t)(uint8_t power_condition, bool start, bool load_eject);
 
   Adafruit_USBD_MSC(void);
 
@@ -53,6 +54,7 @@ public:
                             write_callback_t wr_cb, flush_callback_t fl_cb);
   void setReadyCallback(uint8_t lun, ready_callback_t cb);
   void setWritableCallback(uint8_t lun, writable_callback_t cb);
+  void setStartStopCallback(uint8_t lun, start_stop_callback_t cb);
 
   //------------- Single LUN API -------------//
   void setID(const char *vendor_id, const char *product_id,
@@ -75,6 +77,9 @@ public:
   void setWritableCallback(writable_callback_t cb) {
     setWritableCallback(0, cb);
   }
+  void setStartStopCallback(start_stop_callback_t cb) {
+    setStartStopCallback(0, cb);
+  }
 
   // from Adafruit_USBD_Interface
   virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
@@ -88,6 +93,7 @@ private:
     flush_callback_t fl_cb;
     ready_callback_t ready_cb;
     writable_callback_t writable_cb;
+    start_stop_callback_t start_stop_cb;
 
     const char *_inquiry_vid;
     const char *_inquiry_pid;
@@ -114,6 +120,7 @@ private:
                                     uint8_t *buffer, uint32_t bufsize);
   friend void tud_msc_write10_complete_cb(uint8_t lun);
   friend bool tud_msc_is_writable_cb(uint8_t lun);
+  friend bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start, bool load_eject);
 };
 
 #endif /* ADAFRUIT_USBD_MSC_H_ */


### PR DESCRIPTION
Hi!

I've once again decided to make a PR for setStartStopCallback which allows to detect events like drive ejecting in macOS. I already tried it with PR #138. Now I'm pretty sure that `tud_msc_start_stop_cb()` is actually implemented, so fingers crossed it's all good.