### PR TITLE
Dynamically pick task IRQ for Pico SDK 1.4.0

### DIFF
--- a/src/arduino/ports/rp2040/Adafruit_TinyUSB_rp2040.cpp
+++ b/src/arduino/ports/rp2040/Adafruit_TinyUSB_rp2040.cpp
@@ -45,9 +45,9 @@ extern "C" {
 
 // SDK >= 1.4.0 need to dynamically request the IRQ to avoid conflicts
 #if (PICO_SDK_VERSION_MAJOR * 100 + PICO_SDK_VERSION_MINOR) < 104
-    #define USB_TASK_IRQ 31
+#define USB_TASK_IRQ 31
 #else
-    static unsigned int USB_TASK_IRQ;
+static unsigned int USB_TASK_IRQ;
 #endif
 
 //--------------------------------------------------------------------+

--- a/src/arduino/ports/rp2040/Adafruit_TinyUSB_rp2040.cpp
+++ b/src/arduino/ports/rp2040/Adafruit_TinyUSB_rp2040.cpp
@@ -42,7 +42,13 @@ extern "C" {
 
 // USB processing will be a periodic timer task
 #define USB_TASK_INTERVAL 1000
-#define USB_TASK_IRQ 31
+
+// SDK >= 1.4.0 need to dynamically request the IRQ to avoid conflicts
+#if (PICO_SDK_VERSION_MAJOR * 100 + PICO_SDK_VERSION_MINOR) < 104
+    #define USB_TASK_IRQ 31
+#else
+    static unsigned int USB_TASK_IRQ;
+#endif
 
 //--------------------------------------------------------------------+
 // Forward USB interrupt events to TinyUSB IRQ Handler
@@ -118,6 +124,9 @@ void TinyUSB_Port_InitDevice(uint8_t rhport) {
   tusb_init();
 
   // soft irq for periodically task runner
+#if (PICO_SDK_VERSION_MAJOR * 100 + PICO_SDK_VERSION_MINOR) >= 104
+  USB_TASK_IRQ = user_irq_claim_unused(true);
+#endif
   irq_set_exclusive_handler(USB_TASK_IRQ, usb_irq);
   irq_set_enabled(USB_TASK_IRQ, true);
   setup_periodic_usb_hanlder(USB_TASK_INTERVAL);


### PR DESCRIPTION
The hardcoded periodic USB task IRQ conflicts with the IRQ used by the
new Pico SDK 1.4.0 WiFi support.  A new API call was added in 1.4.0 to
allow the system to select a free IRQ, so use it.  Default to the
hardcoded one on earlier SDK versions (since those don't have the new
API call).

Fixes a crash found in https://github.com/earlephilhower/arduino-pico/pull/670