### PR TITLE
add example for USB host HID report for RP2040

### DIFF
--- a/examples/DualRole/HID_device_report/HID_device_report.ino
+++ b/examples/DualRole/HID_device_report/HID_device_report.ino
@@ -1,0 +1,137 @@
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
+
+
+/* This example demonstrates use of both device and host, where
+ * - Device run on native usb controller (controller0)
+ * - Host run on bit-banging 2 GPIOs with the help of Pico-PIO-USB library (controller1)
+ *
+ * Requirements:
+ * - [Pico-PIO-USB](https://github.com/sekigon-gonnoc/Pico-PIO-USB) library
+ * - 2 consecutive GPIOs: D+ is defined by HOST_PIN_DP (gpio2), D- = D+ +1 (gpio3)
+ * - Provide VBus (5v) and GND for peripheral
+ * - CPU Speed must be either 120 or 240 Mhz. Selected via "Menu -> CPU Speed"
+ *
+ * RP2040 host stack will get device descriptors of attached devices and print it out via
+ * device cdc (Serial) as follows:
+ *    Device 1: ID 046d:c52f
+      Device Descriptor:
+        bLength             18
+        bDescriptorType     1
+        bcdUSB              0200
+        bDeviceClass        0
+        bDeviceSubClass     0
+        bDeviceProtocol     0
+        bMaxPacketSize0     8
+        idVendor            0x046d
+        idProduct           0xc52f
+        bcdDevice           2200
+        iManufacturer       1     Logitech
+        iProduct            2     USB Receiver
+        iSerialNumber       0
+        bNumConfigurations  1
+ *
+ */
+
+// pio-usb is required for rp2040 host
+#include "pio_usb.h"
+#define HOST_PIN_DP   2   // Pin used as D+ for host, D- = D+ + 1
+
+#include "Adafruit_TinyUSB.h"
+
+#define LANGUAGE_ID 0x0409  // English
+
+// USB Host object
+Adafruit_USBH_Host USBHost;
+
+// holding device descriptor
+tusb_desc_device_t desc_device;
+
+// the setup function runs once when you press reset or power the board
+void setup()
+{
+  Serial1.begin(115200);
+
+  Serial.begin(115200);
+  //while ( !Serial ) delay(10);   // wait for native usb
+
+  Serial.println("TinyUSB Dual Device Info Example");
+}
+
+void loop()
+{
+}
+
+// core1's setup
+void setup1() {
+  //while ( !Serial ) delay(10);   // wait for native usb
+  Serial.println("Core1 setup to run TinyUSB host with pio-usb");
+
+  // Check for CPU frequency, must be multiple of 120Mhz for bit-banging USB
+  uint32_t cpu_hz = clock_get_hz(clk_sys);
+  if ( cpu_hz != 120000000UL && cpu_hz != 240000000UL ) {
+    while ( !Serial ) delay(10);   // wait for native usb
+    Serial.printf("Error: CPU Clock = %u, PIO USB require CPU clock must be multiple of 120 Mhz\r\n", cpu_hz);
+    Serial.printf("Change your CPU Clock to either 120 or 240 Mhz in Menu->CPU Speed \r\n", cpu_hz);
+    while(1) delay(1);
+  }
+
+  pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
+  pio_cfg.pin_dp = HOST_PIN_DP;
+  USBHost.configure_pio_usb(1, &pio_cfg);
+
+  // run host stack on controller (rhport) 1
+  // Note: For rp2040 pico-pio-usb, calling USBHost.begin() on core1 will have most of the
+  // host bit-banging processing works done in core1 to free up core0 for other works
+  USBHost.begin(1);
+}
+
+// core1's loop
+void loop1()
+{
+  USBHost.task();
+}
+
+// Invoked when device with hid interface is mounted
+// Report descriptor is also available for use.
+// tuh_hid_parse_report_descriptor() can be used to parse common/simple enough
+// descriptor. Note: if report descriptor length > CFG_TUH_ENUMERATION_BUFSIZE,
+// it will be skipped therefore report_desc = NULL, desc_len = 0
+void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const *desc_report, uint16_t desc_len) {
+  (void)desc_report;
+  (void)desc_len;
+  uint16_t vid, pid;
+  tuh_vid_pid_get(dev_addr, &vid, &pid);
+
+  Serial.printf("HID device address = %d, instance = %d is mounted\r\n", dev_addr, instance);
+  Serial.printf("VID = %04x, PID = %04x\r\n", vid, pid);
+  if (!tuh_hid_receive_report(dev_addr, instance)) {
+    Serial.printf("Error: cannot request to receive report\r\n");
+  }
+}
+
+// Invoked when device with hid interface is un-mounted
+void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance) {
+  Serial.printf("HID device address = %d, instance = %d is unmounted\r\n", dev_addr, instance);
+}
+
+// Invoked when received report from device via interrupt endpoint
+void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t const *report, uint16_t len) {
+  Serial.printf("HIDreport : ");
+  for (uint16_t i = 0; i < len; i++) {
+    Serial.printf("0x%02X ", report[i]);
+  }
+  Serial.println();
+  // continue to request to receive report
+  if (!tuh_hid_receive_report(dev_addr, instance)) {
+    Serial.printf("Error: cannot request to receive report\r\n");
+  }
+}

--- a/src/arduino/Adafruit_USBH_Host.cpp
+++ b/src/arduino/Adafruit_USBH_Host.cpp
@@ -53,7 +53,8 @@ void Adafruit_USBH_Host::task(void) { tuh_task(); }
 // descriptor. Note: if report descriptor length > CFG_TUH_ENUMERATION_BUFSIZE,
 // it will be skipped therefore report_desc = NULL, desc_len = 0
 TU_ATTR_WEAK void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance,
-                      uint8_t const *desc_report, uint16_t desc_len) {
+                                   uint8_t const *desc_report,
+                                   uint16_t desc_len) {
   (void)dev_addr;
   (void)instance;
   (void)desc_report;
@@ -68,7 +69,8 @@ TU_ATTR_WEAK void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance) {
 
 // Invoked when received report from device via interrupt endpoint
 TU_ATTR_WEAK void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance,
-                                uint8_t const *report, uint16_t len) {
+                                             uint8_t const *report,
+                                             uint16_t len) {
   (void)dev_addr;
   (void)instance;
   (void)report;

--- a/src/arduino/Adafruit_USBH_Host.cpp
+++ b/src/arduino/Adafruit_USBH_Host.cpp
@@ -52,7 +52,7 @@ void Adafruit_USBH_Host::task(void) { tuh_task(); }
 // tuh_hid_parse_report_descriptor() can be used to parse common/simple enough
 // descriptor. Note: if report descriptor length > CFG_TUH_ENUMERATION_BUFSIZE,
 // it will be skipped therefore report_desc = NULL, desc_len = 0
-void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance,
+TU_ATTR_WEAK void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance,
                       uint8_t const *desc_report, uint16_t desc_len) {
   (void)dev_addr;
   (void)instance;
@@ -61,13 +61,13 @@ void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance,
 }
 
 // Invoked when device with hid interface is un-mounted
-void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance) {
+TU_ATTR_WEAK void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance) {
   (void)dev_addr;
   (void)instance;
 }
 
 // Invoked when received report from device via interrupt endpoint
-void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance,
+TU_ATTR_WEAK void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance,
                                 uint8_t const *report, uint16_t len) {
   (void)dev_addr;
   (void)instance;


### PR DESCRIPTION
Add example for USB host HID report is simple, but need to modified `Adafruit_USBH_Host.cpp`.
Just need to add weak attribute to every HID callback.