### PR TITLE
Update msc sdfat example to work with SdFat v2

### DIFF
--- a/examples/MassStorage/msc_esp32_file_browser/msc_esp32_file_browser.ino
+++ b/examples/MassStorage/msc_esp32_file_browser/msc_esp32_file_browser.ino
@@ -71,7 +71,7 @@ bool fs_changed;    // Set to true when browser write to flash
 const char* host = "esp32fs";
 WebServer server(80);
 //holds the current upload
-File fsUploadFile;
+File32 fsUploadFile;
 
 //--------------------------------------------------------------------+
 // Setup
@@ -246,7 +246,7 @@ String getContentType(String filename) {
 
 bool exists(String path){
   bool yes = false;
-  File file = fatfs.open(path, O_READ);
+  File32 file = fatfs.open(path, O_READ);
   if(file && !file.isDirectory()){
     yes = true;
   }
@@ -265,7 +265,7 @@ bool handleFileRead(String path) {
 //    if (exists(pathWithGz)) {
 //      path += ".gz";
 //    }
-    File file = fatfs.open(path, O_READ);
+    File32 file = fatfs.open(path, O_READ);
     server.streamFile(file, contentType);
     file.close();
     return true;
@@ -333,7 +333,7 @@ void handleFileCreate() {
   if (exists(path)) {
     return server.send(500, "text/plain", "FILE EXISTS");
   }
-  File file = fatfs.open(path, O_WRITE | O_CREAT);
+  File32 file = fatfs.open(path, O_WRITE | O_CREAT);
   if (file) {
     file.close();
   } else {
@@ -352,12 +352,12 @@ void handleFileList() {
   String path = server.arg("dir");
   DBG_SERIAL.println("handleFileList: " + path);
 
-  File root = fatfs.open(path);
+  File32 root = fatfs.open(path);
   path = String();
 
   String output = "[";
   if(root.isDirectory()){
-      File file = root.openNextFile();
+      File32 file = root.openNextFile();
       char fname[256];
       while(file){
           if (output != "[") {

--- a/examples/MassStorage/msc_esp32_file_browser/msc_esp32_file_browser.ino
+++ b/examples/MassStorage/msc_esp32_file_browser/msc_esp32_file_browser.ino
@@ -60,7 +60,7 @@ Adafruit_FlashTransport_ESP32 flashTransport;
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
-FatFileSystem fatfs;
+FatVolume fatfs;
 
 // USB Mass Storage object
 Adafruit_USBD_MSC usb_msc;

--- a/examples/MassStorage/msc_external_flash/flash_config.h
+++ b/examples/MassStorage/msc_external_flash/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/MassStorage/msc_external_flash/flash_config.h
+++ b/examples/MassStorage/msc_external_flash/flash_config.h
@@ -33,34 +33,41 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
+
 // ESP32 use same flash device that store code for file system.
 // SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
+
 // RP2040 use same flash device that store code for file system. Therefore we
 // only need to specify start address and size (no need SPI or SS)
-//   Adafruit_FlashTransport_RP2040(start_address, size)
-// If start = 0, size = 0 (default), values that match file system setting in
+// By default (start=0, size=0), values that match file system setting in
 // 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
 // To be compatible with CircuitPython partition scheme (start_address = 1 MB,
-// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
-// Un-comment following line:
-// Adafruit_FlashTransport_RP2040
-//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
-//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE) or
+// subclass Adafruit_FlashTransport_RP2040_CPY. Un-comment either of the
+// following line:
+//  Adafruit_FlashTransport_RP2040
+//    flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                   Adafruit_FlashTransport_RP2040::CPY_SIZE);
+//  Adafruit_FlashTransport_RP2040_CPY flashTransport;
 
 #else
+
 // On-board external flash (QSPI or SPI) macros should already
 // defined in your board variant if supported
 // - EXTERNAL_FLASH_USE_QSPI
 // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+
 #if defined(EXTERNAL_FLASH_USE_QSPI)
+
 Adafruit_FlashTransport_QSPI flashTransport;
 
 #elif defined(EXTERNAL_FLASH_USE_SPI)
+
 Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
                                            EXTERNAL_FLASH_USE_SPI);
 

--- a/examples/MassStorage/msc_external_flash/flash_config.h
+++ b/examples/MassStorage/msc_external_flash/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,43 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/MassStorage/msc_external_flash/msc_external_flash.ino
+++ b/examples/MassStorage/msc_external_flash/msc_external_flash.ino
@@ -27,44 +27,8 @@
 #include "Adafruit_SPIFlash.h"
 #include "Adafruit_TinyUSB.h"
 
-// Un-comment to run example with custom SPI SPI and SS e.g with FRAM breakout
-// #define CUSTOM_CS   A5
-// #define CUSTOM_SPI  SPI
-
-#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
-
-#elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage:
-  //    Adafruit_FlashTransport_RP2040 flashTransport(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 

--- a/examples/MassStorage/msc_external_flash/msc_external_flash.ino
+++ b/examples/MassStorage/msc_external_flash/msc_external_flash.ino
@@ -69,7 +69,7 @@
 Adafruit_SPIFlash flash(&flashTransport);
 
 // file system object from SdFat
-FatFileSystem fatfs;
+FatVolume fatfs;
 
 FatFile root;
 FatFile file;

--- a/examples/MassStorage/msc_external_flash_sdcard/flash_config.h
+++ b/examples/MassStorage/msc_external_flash_sdcard/flash_config.h
@@ -1,0 +1,67 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef FLASH_CONFIG_H_
+#define FLASH_CONFIG_H_
+
+// Un-comment to run example with custom SPI and SS e.g with FRAM breakout
+// #define CUSTOM_CS   A5
+// #define CUSTOM_SPI  SPI
+
+#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
+  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+
+#elif defined(ARDUINO_ARCH_ESP32)
+  // ESP32 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  Adafruit_FlashTransport_ESP32 flashTransport;
+
+#elif defined(ARDUINO_ARCH_RP2040)
+  // RP2040 use same flash device that store code.
+  // Therefore there is no need to specify the SPI and SS
+  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
+  Adafruit_FlashTransport_RP2040 flashTransport;
+
+  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
+  // If start_address and size are both 0, value that match filesystem setting in
+  // 'Tools->Flash Size' menu selection will be used
+
+#else
+  // On-board external flash (QSPI or SPI) macros should already
+  // defined in your board variant if supported
+  // - EXTERNAL_FLASH_USE_QSPI
+  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+  #if defined(EXTERNAL_FLASH_USE_QSPI)
+    Adafruit_FlashTransport_QSPI flashTransport;
+
+  #elif defined(EXTERNAL_FLASH_USE_SPI)
+    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+
+  #else
+    #error No (Q)SPI flash are defined for your board !
+  #endif
+#endif
+
+
+#endif

--- a/examples/MassStorage/msc_external_flash_sdcard/flash_config.h
+++ b/examples/MassStorage/msc_external_flash_sdcard/flash_config.h
@@ -33,34 +33,41 @@
 Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
+
 // ESP32 use same flash device that store code for file system.
 // SPIFlash will parse partition.cvs to detect FATFS partition to use
 Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
+
 // RP2040 use same flash device that store code for file system. Therefore we
 // only need to specify start address and size (no need SPI or SS)
-//   Adafruit_FlashTransport_RP2040(start_address, size)
-// If start = 0, size = 0 (default), values that match file system setting in
+// By default (start=0, size=0), values that match file system setting in
 // 'Tools->Flash Size' menu selection will be used.
 Adafruit_FlashTransport_RP2040 flashTransport;
 
 // To be compatible with CircuitPython partition scheme (start_address = 1 MB,
-// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
-// Un-comment following line:
-// Adafruit_FlashTransport_RP2040
-//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
-//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE) or
+// subclass Adafruit_FlashTransport_RP2040_CPY. Un-comment either of the
+// following line:
+//  Adafruit_FlashTransport_RP2040
+//    flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                   Adafruit_FlashTransport_RP2040::CPY_SIZE);
+//  Adafruit_FlashTransport_RP2040_CPY flashTransport;
 
 #else
+
 // On-board external flash (QSPI or SPI) macros should already
 // defined in your board variant if supported
 // - EXTERNAL_FLASH_USE_QSPI
 // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+
 #if defined(EXTERNAL_FLASH_USE_QSPI)
+
 Adafruit_FlashTransport_QSPI flashTransport;
 
 #elif defined(EXTERNAL_FLASH_USE_SPI)
+
 Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
                                            EXTERNAL_FLASH_USE_SPI);
 

--- a/examples/MassStorage/msc_external_flash_sdcard/flash_config.h
+++ b/examples/MassStorage/msc_external_flash_sdcard/flash_config.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -30,38 +30,43 @@
 // #define CUSTOM_SPI  SPI
 
 #if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
+Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
 
 #elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
+// ESP32 use same flash device that store code for file system.
+// SPIFlash will parse partition.cvs to detect FATFS partition to use
+Adafruit_FlashTransport_ESP32 flashTransport;
 
 #elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
+// RP2040 use same flash device that store code for file system. Therefore we
+// only need to specify start address and size (no need SPI or SS)
+//   Adafruit_FlashTransport_RP2040(start_address, size)
+// If start = 0, size = 0 (default), values that match file system setting in
+// 'Tools->Flash Size' menu selection will be used.
+Adafruit_FlashTransport_RP2040 flashTransport;
 
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
+// To be compatible with CircuitPython partition scheme (start_address = 1 MB,
+// size = total flash - 1 MB) use const value (CPY_START_ADDR, CPY_SIZE).
+// Un-comment following line:
+// Adafruit_FlashTransport_RP2040
+//     flashTransport(Adafruit_FlashTransport_RP2040::CPY_START_ADDR,
+//                    Adafruit_FlashTransport_RP2040::CPY_SIZE);
 
 #else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
+// On-board external flash (QSPI or SPI) macros should already
+// defined in your board variant if supported
+// - EXTERNAL_FLASH_USE_QSPI
+// - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
+#if defined(EXTERNAL_FLASH_USE_QSPI)
+Adafruit_FlashTransport_QSPI flashTransport;
 
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
+#elif defined(EXTERNAL_FLASH_USE_SPI)
+Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS,
+                                           EXTERNAL_FLASH_USE_SPI);
 
-  #else
-    #error No (Q)SPI flash are defined for your board !
-  #endif
+#else
+#error No (Q)SPI flash are defined for your board !
 #endif
-
+#endif
 
 #endif

--- a/examples/MassStorage/msc_external_flash_sdcard/msc_external_flash_sdcard.ino
+++ b/examples/MassStorage/msc_external_flash_sdcard/msc_external_flash_sdcard.ino
@@ -28,44 +28,8 @@
 // External Flash Config
 //--------------------------------------------------------------------+
 
-// Un-comment to run example with custom SPI SPI and SS e.g with FRAM breakout
-// #define CUSTOM_CS   A5
-// #define CUSTOM_SPI  SPI
-
-#if defined(CUSTOM_CS) && defined(CUSTOM_SPI)
-  Adafruit_FlashTransport_SPI flashTransport(CUSTOM_CS, CUSTOM_SPI);
-
-#elif defined(ARDUINO_ARCH_ESP32)
-  // ESP32 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  Adafruit_FlashTransport_ESP32 flashTransport;
-
-#elif defined(ARDUINO_ARCH_RP2040)
-  // RP2040 use same flash device that store code.
-  // Therefore there is no need to specify the SPI and SS
-  // Use default (no-args) constructor to be compatible with CircuitPython partition scheme
-  Adafruit_FlashTransport_RP2040 flashTransport;
-
-  // For generic usage: Adafruit_FlashTransport_RP2040(start_address, size)
-  // If start_address and size are both 0, value that match filesystem setting in
-  // 'Tools->Flash Size' menu selection will be used
-
-#else
-  // On-board external flash (QSPI or SPI) macros should already
-  // defined in your board variant if supported
-  // - EXTERNAL_FLASH_USE_QSPI
-  // - EXTERNAL_FLASH_USE_CS/EXTERNAL_FLASH_USE_SPI
-  #if defined(EXTERNAL_FLASH_USE_QSPI)
-    Adafruit_FlashTransport_QSPI flashTransport;
-
-  #elif defined(EXTERNAL_FLASH_USE_SPI)
-    Adafruit_FlashTransport_SPI flashTransport(EXTERNAL_FLASH_USE_CS, EXTERNAL_FLASH_USE_SPI);
-
-  #else
-    #error No QSPI/SPI flash are defined on your board variant.h !
-  #endif
-#endif
-
+// for flashTransport definition
+#include "flash_config.h"
 
 Adafruit_SPIFlash flash(&flashTransport);
 
@@ -176,9 +140,9 @@ bool init_sdcard(void)
   return true;
 }
 
-void print_rootdir(File* rdir)
+void print_rootdir(File32* rdir)
 {
-  File file;
+  File32 file;
 
   // Open next file in root.
   // Warning, openNext starts at the current directory position
@@ -210,7 +174,7 @@ void loop()
     // skip if still not formatted
     if (flash_formatted)
     {
-      File root;
+      File32 root;
       root = fatfs.open("/");
 
       Serial.println("Flash contents:");
@@ -225,7 +189,7 @@ void loop()
 
   if ( sd_changed )
   {
-    File root;
+    File32 root;
     root = sd.open("/");
 
     Serial.println("SD contents:");

--- a/examples/MassStorage/msc_internal_flash_samd/msc_internal_flash_samd.ino
+++ b/examples/MassStorage/msc_internal_flash_samd/msc_internal_flash_samd.ino
@@ -23,7 +23,7 @@
 Adafruit_InternalFlash flash(INTERNAL_FLASH_FILESYSTEM_START_ADDR, INTERNAL_FLASH_FILESYSTEM_SIZE);
 
 // file system object from SdFat
-FatFileSystem fatfs;
+FatVolume fatfs;
 
 FatFile root;
 FatFile file;


### PR DESCRIPTION
some of new name such as File32 is not available in v1 (we can continue to use v1 symbol) but this is to illustrate how to migrate to SdFat v2. PR should work after 
- https://github.com/adafruit/Adafruit_SPIFlash/pull/127
- https://github.com/adafruit/SdFat/pull/13