### PR TITLE
MIDI: support port name strings

### DIFF
--- a/examples/MIDI/midi_multi_ports/midi_multi_ports.ino
+++ b/examples/MIDI/midi_multi_ports/midi_multi_ports.ino
@@ -1,0 +1,46 @@
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
+
+// This sketch is enumerated as USB MIDI device with multiple ports
+// and how to set their name
+
+#include <Arduino.h>
+#include <Adafruit_TinyUSB.h>
+#include <MIDI.h>
+
+// USB MIDI object with 3 ports
+Adafruit_USBD_MIDI usb_midi(3);
+
+void setup()
+{
+  pinMode(LED_BUILTIN, OUTPUT);
+
+#if defined(ARDUINO_ARCH_MBED) && defined(ARDUINO_ARCH_RP2040)
+  // Manual begin() is required on core without built-in support for TinyUSB such as mbed rp2040
+  TinyUSB_Device_Init(0);
+#endif
+
+  // Set name for each cable, must be done before usb_midi.begin()
+  usb_midi.setCableName(1, "Keyboard");
+  usb_midi.setCableName(2, "Drum Pads");
+  usb_midi.setCableName(3, "Lights");
+
+  usb_midi.begin();
+}
+
+void loop()
+{
+  digitalWrite(LED_BUILTIN, HIGH);
+  delay(1000);
+
+  digitalWrite(LED_BUILTIN, LOW);
+  delay(1000);
+}

--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -126,9 +126,10 @@ void Adafruit_USBD_Device::setSerialDescriptor(const char *s) {
   _desc_str_arr[STRID_SERIAL] = s;
 }
 
-uint8_t Adafruit_USBD_Device::addStringToIndex(const char *s) {
-  if (_desc_str_count >= STRING_DESCRIPTOR_MAX)
+uint8_t Adafruit_USBD_Device::addStringDescriptor(const char *s) {
+  if (_desc_str_count >= STRING_DESCRIPTOR_MAX) {
     return 0;
+  }
 
   uint8_t index = _desc_str_count++;
   _desc_str_arr[index] = s;

--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -126,6 +126,8 @@ void Adafruit_USBD_Device::setSerialDescriptor(const char *s) {
   _desc_str_arr[STRID_SERIAL] = s;
 }
 
+// Add a string descriptor to the device's pool
+// Return string index
 uint8_t Adafruit_USBD_Device::addStringDescriptor(const char *s) {
   if (_desc_str_count >= STRING_DESCRIPTOR_MAX || s == NULL) {
     return 0;

--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -127,7 +127,7 @@ void Adafruit_USBD_Device::setSerialDescriptor(const char *s) {
 }
 
 uint8_t Adafruit_USBD_Device::addStringDescriptor(const char *s) {
-  if (_desc_str_count >= STRING_DESCRIPTOR_MAX) {
+  if (_desc_str_count >= STRING_DESCRIPTOR_MAX || s == NULL) {
     return 0;
   }
 

--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -126,6 +126,15 @@ void Adafruit_USBD_Device::setSerialDescriptor(const char *s) {
   _desc_str_arr[STRID_SERIAL] = s;
 }
 
+uint8_t Adafruit_USBD_Device::addStringToIndex(const char *s) {
+  if (_desc_str_count >= STRING_DESCRIPTOR_MAX)
+    return 0;
+
+  uint8_t index = _desc_str_count++;
+  _desc_str_arr[index] = s;
+  return index;
+}
+
 void Adafruit_USBD_Device::task(void) { tud_task(); }
 
 bool Adafruit_USBD_Device::mounted(void) { return tud_mounted(); }

--- a/src/arduino/Adafruit_USBD_Device.h
+++ b/src/arduino/Adafruit_USBD_Device.h
@@ -87,6 +87,7 @@ public:
   void setProductDescriptor(const char *s);
   void setSerialDescriptor(const char *s);
   uint8_t getSerialDescriptor(uint16_t *serial_utf16);
+  uint8_t addStringToIndex(const char *s);
 
   //------------- Control -------------//
 

--- a/src/arduino/Adafruit_USBD_Device.h
+++ b/src/arduino/Adafruit_USBD_Device.h
@@ -34,7 +34,7 @@
 
 class Adafruit_USBD_Device {
 private:
-  enum { STRING_DESCRIPTOR_MAX = 8 };
+  enum { STRING_DESCRIPTOR_MAX = 12 };
 
   // Device descriptor
   tusb_desc_device_t _desc_device __attribute__((aligned(4)));
@@ -87,7 +87,8 @@ public:
   void setProductDescriptor(const char *s);
   void setSerialDescriptor(const char *s);
   uint8_t getSerialDescriptor(uint16_t *serial_utf16);
-  uint8_t addStringToIndex(const char *s);
+
+  uint8_t addStringDescriptor(const char *s);
 
   //------------- Control -------------//
 

--- a/src/arduino/midi/Adafruit_USBD_MIDI.cpp
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.cpp
@@ -105,7 +105,7 @@ uint16_t Adafruit_USBD_MIDI::makeItfDesc(uint8_t itfnum, uint8_t *buf,
 
   // Jack
   for (uint8_t i = 1; i <= _n_cables; i++) {
-    uint8_t jack[] = {TUD_MIDI_DESC_JACK(i)};
+    uint8_t jack[] = {TUD_MIDI_DESC_JACK_DESC(i, _cable_name_strings[i])};
     memcpy(buf + len, jack, sizeof(jack));
     len += sizeof(jack);
   }

--- a/src/arduino/midi/Adafruit_USBD_MIDI.cpp
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.cpp
@@ -58,7 +58,7 @@ static uint16_t midi_load_descriptor(uint8_t *dst, uint8_t *itf) {
 
 Adafruit_USBD_MIDI::Adafruit_USBD_MIDI(uint8_t n_cables) {
   _n_cables = n_cables;
-  memcpy(_cable_name_strid, 0, sizeof(_cable_name_strid));
+  memset(_cable_name_strid, 0, sizeof(_cable_name_strid));
 
 #ifdef ARDUINO_ARCH_ESP32
   // ESP32 requires setup configuration descriptor within constructor

--- a/src/arduino/midi/Adafruit_USBD_MIDI.h
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.h
@@ -34,12 +34,10 @@ public:
 
   void setCables(uint8_t n_cables);
 
-  // Register the index number of a USB device descriptor string, which was
-  // added with Adafruit_USBD_Device::addStringToIndex().
-  void setCableNameStringIndex(uint8_t index, uint8_t string_index) {
-    _cable_name_strings[index] = string_index;
-  }
-
+  // Set the cable number with a USB device descriptor string
+  // Note: per MIDI specs cable_id (or jackid/elementid) starting from 1. 0 is
+  // reserved for undefined ID.
+  bool setCableName(uint8_t cable_id, const char *str);
   bool begin(void);
 
   // for MIDI library
@@ -71,7 +69,7 @@ public:
 
 private:
   uint8_t _n_cables;
-  uint8_t _cable_name_strings[16]{};
+  uint8_t _cable_name_strid[8];
 };
 
 #endif /* ADAFRUIT_USBD_MIDI_H_ */

--- a/src/arduino/midi/Adafruit_USBD_MIDI.h
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.h
@@ -34,6 +34,12 @@ public:
 
   void setCables(uint8_t n_cables);
 
+  // Register the index number of a USB device descriptor string, which was
+  // added with Adafruit_USBD_Device::addStringToIndex().
+  void setCableNameStringIndex(uint8_t index, uint8_t string_index) {
+    _cable_name_strings[index] = string_index;
+  }
+
   bool begin(void);
 
   // for MIDI library
@@ -65,6 +71,7 @@ public:
 
 private:
   uint8_t _n_cables;
+  uint8_t _cable_name_strings[16]{};
 };
 
 #endif /* ADAFRUIT_USBD_MIDI_H_ */


### PR DESCRIPTION
# MIDI port names

This patch allows to set custom descriptive names for virtual MIDI ports/cables. A MIDI port offers different functionality on the same physical USB device. The names make it easier to distinguish one from the other.

Edit: the tinyusb part was merged: https://github.com/hathach/tinyusb/pull/1738

# Screenshot of Chrome on MacOS listing WebMIDI devices:
<img width="548" alt="Screenshot 2022-11-10 at 17 03 00" src="https://user-images.githubusercontent.com/1064936/201146950-028ab1c3-7c2b-4239-8929-02f7130d8194.png">

# Screenshot of MacOS system-level MIDI Setup
<img width="639" alt="Screenshot 2022-11-10 at 17 02 35" src="https://user-images.githubusercontent.com/1064936/201146906-d052aa1d-9832-4418-9703-5fcf9280c995.png">

# Example calls in setup() of Arduino sketch:

```c
  Device.usb.midi.setPortName(1, "Keyboard");
  Device.usb.midi.setPortName(2, "Drum Pads");
  Device.usb.midi.setPortName(3, "Lights");
```

# Calls to Adafruit_TinyUSB_Arduino from a local/custom MIDI Library:

```c
  void setPorts(uint8_t n_ports) {
    _midi.interface.setCables(n_ports);
  }

  void setPortName(uint8_t port, const char *name) {
    _midi.interface.setCableNameStringIndex(port, _device.device->addStringToIndex(name));
  }
```