### PR TITLE
Add Host cdc support 

### DIFF
--- a/examples/DualRole/serial_host_bridge/serial_host_bridge.ino
+++ b/examples/DualRole/serial_host_bridge/serial_host_bridge.ino
@@ -1,0 +1,154 @@
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
+
+
+/* This example demonstrates use of Host Serial (CDC). SerialHost (declared below) is
+ * an object to manage an CDC peripheral connected to our USB Host connector. This example
+ * will forward all characters from Serial to SerialHost and vice versa.
+ *
+ * Note:
+ * - Device run on native usb controller (controller0)
+ * - Host run on bit-banging 2 GPIOs with the help of Pico-PIO-USB library (controller1)
+
+ * Requirements:
+ * - [Pico-PIO-USB](https://github.com/sekigon-gonnoc/Pico-PIO-USB) library
+ * - 2 consecutive GPIOs: D+ is defined by HOST_PIN_DP (gpio20), D- = D+ +1 (gpio21)
+ * - Provide VBus (5v) and GND for peripheral
+ * - CPU Speed must be either 120 or 240 Mhz. Selected via "Menu -> CPU Speed"
+ */
+
+// pio-usb is required for rp2040 host
+#include "pio_usb.h"
+
+// TinyUSB lib
+#include "Adafruit_TinyUSB.h"
+
+// Pin D+ for host, D- = D+ + 1
+#define HOST_PIN_DP       20
+
+// Pin for enabling Host VBUS. comment out if not used
+#define HOST_PIN_VBUS_EN        22
+#define HOST_PIN_VBUS_EN_STATE  1
+
+// USB Host object
+Adafruit_USBH_Host USBHost;
+
+// CDC Host object
+Adafruit_USBH_CDC  SerialHost;
+
+//--------------------------------------------------------------------+
+// Setup and Loop on Core0
+//--------------------------------------------------------------------+
+
+void setup() {
+  Serial1.begin(115200);
+
+  Serial.begin(115200);
+  while ( !Serial ) delay(10);   // wait for native usb
+
+  Serial.println("TinyUSB Host Serial Echo Example");
+}
+
+void loop()
+{
+  uint8_t buf[64];
+
+  // Serial -> SerialHost
+  if (Serial.available()) {
+    size_t count = Serial.read(buf, sizeof(buf));
+    if ( SerialHost && SerialHost.connected() ) {
+      SerialHost.write(buf, count);
+      SerialHost.flush();
+    }
+  }
+
+  // SerialHost -> Serial
+  if ( SerialHost.connected() && SerialHost.available() ) {
+    size_t count = SerialHost.read(buf, sizeof(buf));
+    Serial.write(buf, count);
+  }
+}
+
+//--------------------------------------------------------------------+
+// Setup and Loop on Core1
+//--------------------------------------------------------------------+
+
+void setup1() {
+  while ( !Serial ) delay(10);   // wait for native usb
+  Serial.println("Core1 setup to run TinyUSB host with pio-usb");
+
+  // Check for CPU frequency, must be multiple of 120Mhz for bit-banging USB
+  uint32_t cpu_hz = clock_get_hz(clk_sys);
+  if ( cpu_hz != 120000000UL && cpu_hz != 240000000UL ) {
+    while ( !Serial ) {
+      delay(10);   // wait for native usb
+    }
+    Serial.printf("Error: CPU Clock = %u, PIO USB require CPU clock must be multiple of 120 Mhz\r\n", cpu_hz);
+    Serial.printf("Change your CPU Clock to either 120 or 240 Mhz in Menu->CPU Speed \r\n", cpu_hz);
+    while(1) {
+      delay(1);
+    }
+  }
+
+#ifdef HOST_PIN_VBUS_EN
+  pinMode(HOST_PIN_VBUS_EN, OUTPUT);
+
+  // power off first
+  digitalWrite(HOST_PIN_VBUS_EN, 1-HOST_PIN_VBUS_EN_STATE);
+  delay(1);
+
+  // power on
+  digitalWrite(HOST_PIN_VBUS_EN, HOST_PIN_VBUS_EN_STATE);
+  delay(10);
+#endif
+
+  pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
+  pio_cfg.pin_dp = HOST_PIN_DP;
+  USBHost.configure_pio_usb(1, &pio_cfg);
+
+  // run host stack on controller (rhport) 1
+  // Note: For rp2040 pico-pio-usb, calling USBHost.begin() on core1 will have most of the
+  // host bit-banging processing works done in core1 to free up core0 for other works
+  USBHost.begin(1);
+}
+
+void loop1()
+{
+  USBHost.task();
+
+  // periodically flush SerialHost if connected
+  if ( SerialHost && SerialHost.connected() ) {
+    SerialHost.flush();
+  }
+}
+
+//--------------------------------------------------------------------+
+// TinyUSB Host callbacks
+//--------------------------------------------------------------------+
+
+// Invoked when a device with CDC interface is mounted
+// idx is index of cdc interface in the internal pool.
+void tuh_cdc_mount_cb(uint8_t idx) {
+  // bind SerialHost object to this interface index
+  SerialHost.begin(idx);
+
+  Serial.println("SerialHost is connected to a new CDC device");
+}
+
+// Invoked when a device with CDC interface is unmounted
+void tuh_cdc_umount_cb(uint8_t idx) {
+  if (idx == SerialHost.getIndex()) {
+    // unbind SerialHost if this interface is unmounted
+    SerialHost.end();
+
+    Serial.println("SerialHost is disconnected");
+  }
+}

--- a/src/Adafruit_TinyUSB.h
+++ b/src/Adafruit_TinyUSB.h
@@ -37,6 +37,7 @@
 #if TUSB_OPT_DEVICE_ENABLED
 
 #include "arduino/Adafruit_USBD_Device.h"
+
 #if CFG_TUD_CDC
   #include "arduino/Adafruit_USBD_CDC.h"
 #endif
@@ -44,12 +45,15 @@
 #if CFG_TUD_HID
   #include "arduino/hid/Adafruit_USBD_HID.h"
 #endif
+
 #if CFG_TUD_MIDI
   #include "arduino/midi/Adafruit_USBD_MIDI.h"
 #endif
+
 #if CFG_TUD_MSC
   #include "arduino/msc/Adafruit_USBD_MSC.h"
 #endif
+
 #if CFG_TUD_VENDOR
   #include "arduino/webusb/Adafruit_USBD_WebUSB.h"
 #endif
@@ -64,6 +68,11 @@ void TinyUSB_Device_Init(uint8_t rhport);
 #if CFG_TUH_ENABLED
 
 #include "arduino/Adafruit_USBH_Host.h"
+
+#if CFG_TUH_CDC
+  #include "arduino/cdc/Adafruit_USBH_CDC.h"
+#endif
+
 #if CFG_TUH_MSC
   #include "arduino/msc/Adafruit_USBH_MSC.h"
 #endif

--- a/src/arduino/cdc/Adafruit_USBH_CDC.cpp
+++ b/src/arduino/cdc/Adafruit_USBH_CDC.cpp
@@ -40,7 +40,7 @@ bool Adafruit_USBH_CDC::connected(void) {
   return (_idx != TUSB_INDEX_INVALID) && tuh_cdc_connected(_idx);
 }
 
-Adafruit_USBH_CDC::operator bool() {
+bool Adafruit_USBH_CDC::mounted(void) {
   return (_idx != TUSB_INDEX_INVALID) && tuh_cdc_mounted(_idx);
 }
 

--- a/src/arduino/cdc/Adafruit_USBH_CDC.cpp
+++ b/src/arduino/cdc/Adafruit_USBH_CDC.cpp
@@ -30,17 +30,11 @@
 
 #include "Adafruit_USBH_CDC.h"
 
-Adafruit_USBH_CDC::Adafruit_USBH_CDC(void) {
-  _idx = TUSB_INDEX_INVALID;
-}
+Adafruit_USBH_CDC::Adafruit_USBH_CDC(void) { _idx = TUSB_INDEX_INVALID; }
 
-void Adafruit_USBH_CDC::begin(uint8_t idx) {
-  _idx = idx;
-}
+void Adafruit_USBH_CDC::begin(uint8_t idx) { _idx = idx; }
 
-void Adafruit_USBH_CDC::end(void) {
-  _idx = TUSB_INDEX_INVALID;
-}
+void Adafruit_USBH_CDC::end(void) { _idx = TUSB_INDEX_INVALID; }
 
 bool Adafruit_USBH_CDC::connected(void) {
   return (_idx != TUSB_INDEX_INVALID) && tuh_cdc_connected(_idx);
@@ -51,7 +45,7 @@ Adafruit_USBH_CDC::operator bool() {
 }
 
 int Adafruit_USBH_CDC::available(void) {
-  return (int) tuh_cdc_read_available(_idx);
+  return (int)tuh_cdc_read_available(_idx);
 }
 
 int Adafruit_USBH_CDC::peek(void) {
@@ -61,20 +55,16 @@ int Adafruit_USBH_CDC::peek(void) {
 
 int Adafruit_USBH_CDC::read(void) {
   uint8_t ch;
-  return read(&ch, 1) ? (int) ch : -1;
+  return read(&ch, 1) ? (int)ch : -1;
 }
 
 size_t Adafruit_USBH_CDC::read(uint8_t *buffer, size_t size) {
   return tuh_cdc_read(_idx, buffer, size);
 }
 
-void Adafruit_USBH_CDC::flush(void) {
-  (void) tuh_cdc_write_flush(_idx);
-}
+void Adafruit_USBH_CDC::flush(void) { (void)tuh_cdc_write_flush(_idx); }
 
-size_t Adafruit_USBH_CDC::write(uint8_t ch) {
-  return write(&ch, 1);
-}
+size_t Adafruit_USBH_CDC::write(uint8_t ch) { return write(&ch, 1); }
 
 size_t Adafruit_USBH_CDC::write(const uint8_t *buffer, size_t size) {
   size_t remain = size;
@@ -95,7 +85,7 @@ size_t Adafruit_USBH_CDC::write(const uint8_t *buffer, size_t size) {
 }
 
 int Adafruit_USBH_CDC::availableForWrite(void) {
-  return (int) tuh_cdc_write_available(_idx);
+  return (int)tuh_cdc_write_available(_idx);
 }
 
 #endif

--- a/src/arduino/cdc/Adafruit_USBH_CDC.cpp
+++ b/src/arduino/cdc/Adafruit_USBH_CDC.cpp
@@ -1,0 +1,101 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "tusb_option.h"
+
+#if CFG_TUH_ENABLED && CFG_TUH_MSC
+
+#include "tusb.h"
+
+#include "Adafruit_USBH_CDC.h"
+
+Adafruit_USBH_CDC::Adafruit_USBH_CDC(void) {
+  _idx = TUSB_INDEX_INVALID;
+}
+
+void Adafruit_USBH_CDC::begin(uint8_t idx) {
+  _idx = idx;
+}
+
+void Adafruit_USBH_CDC::end(void) {
+  _idx = TUSB_INDEX_INVALID;
+}
+
+bool Adafruit_USBH_CDC::connected(void) {
+  return (_idx != TUSB_INDEX_INVALID) && tuh_cdc_connected(_idx);
+}
+
+Adafruit_USBH_CDC::operator bool() {
+  return (_idx != TUSB_INDEX_INVALID) && tuh_cdc_mounted(_idx);
+}
+
+int Adafruit_USBH_CDC::available(void) {
+  return (int) tuh_cdc_read_available(_idx);
+}
+
+int Adafruit_USBH_CDC::peek(void) {
+  // TODO support later
+  return -1;
+}
+
+int Adafruit_USBH_CDC::read(void) {
+  uint8_t ch;
+  return read(&ch, 1) ? (int) ch : -1;
+}
+
+size_t Adafruit_USBH_CDC::read(uint8_t *buffer, size_t size) {
+  return tuh_cdc_read(_idx, buffer, size);
+}
+
+void Adafruit_USBH_CDC::flush(void) {
+  (void) tuh_cdc_write_flush(_idx);
+}
+
+size_t Adafruit_USBH_CDC::write(uint8_t ch) {
+  return write(&ch, 1);
+}
+
+size_t Adafruit_USBH_CDC::write(const uint8_t *buffer, size_t size) {
+  size_t remain = size;
+  while (remain && tuh_cdc_mounted(_idx)) {
+    size_t wrcount = tuh_cdc_write(_idx, buffer, remain);
+    remain -= wrcount;
+    buffer += wrcount;
+
+    // Write FIFO is full, run host task while wait for space become available
+    if (remain) {
+      tuh_task();
+    }
+  }
+
+  return size - remain;
+
+  return tuh_cdc_write(_idx, buffer, size);
+}
+
+int Adafruit_USBH_CDC::availableForWrite(void) {
+  return (int) tuh_cdc_write_available(_idx);
+}
+
+#endif

--- a/src/arduino/cdc/Adafruit_USBH_CDC.h
+++ b/src/arduino/cdc/Adafruit_USBH_CDC.h
@@ -41,7 +41,8 @@ public:
   uint8_t getIndex(void) { return _idx; }
 
   // If cdc is mounted
-  operator bool();
+  bool mounted(void);
+  operator bool() { return mounted(); }
 
   // if cdc's DTR is asserted
   bool connected(void);

--- a/src/arduino/cdc/Adafruit_USBH_CDC.h
+++ b/src/arduino/cdc/Adafruit_USBH_CDC.h
@@ -1,4 +1,4 @@
-/* 
+/*
  * The MIT License (MIT)
  *
  * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
@@ -29,43 +29,43 @@
 
 class Adafruit_USBH_CDC : public Stream {
 public:
-    Adafruit_USBH_CDC(void);
+  Adafruit_USBH_CDC(void);
 
-    // Init/Bind to an specific cdc interface
-    void begin(uint8_t idx = 0);
+  // Init/Bind to an specific cdc interface
+  void begin(uint8_t idx = 0);
 
-    // unbind cdc interface
-    void end(void);
+  // unbind cdc interface
+  void end(void);
 
-    // Get index of cdc interface
-    uint8_t getIndex(void) { return _idx; }
+  // Get index of cdc interface
+  uint8_t getIndex(void) { return _idx; }
 
-    // If cdc is mounted
-    operator bool();
+  // If cdc is mounted
+  operator bool();
 
-    // if cdc's DTR is asserted
-    bool connected(void);
+  // if cdc's DTR is asserted
+  bool connected(void);
 
-    //------------- Stream API -------------//
-    virtual int available(void);
-    virtual int peek(void);
+  //------------- Stream API -------------//
+  virtual int available(void);
+  virtual int peek(void);
 
-    virtual int read(void);
-    size_t read(uint8_t *buffer, size_t size);
+  virtual int read(void);
+  size_t read(uint8_t *buffer, size_t size);
 
-    virtual void flush(void);
-    virtual size_t write(uint8_t ch);
+  virtual void flush(void);
+  virtual size_t write(uint8_t ch);
 
-    virtual size_t write(const uint8_t *buffer, size_t size);
-    size_t write(const char *buffer, size_t size) {
-      return write((const uint8_t *)buffer, size);
-    }
+  virtual size_t write(const uint8_t *buffer, size_t size);
+  size_t write(const char *buffer, size_t size) {
+    return write((const uint8_t *)buffer, size);
+  }
 
-    virtual int availableForWrite(void);
-    using Print::write; // pull in write(str) from Print
+  virtual int availableForWrite(void);
+  using Print::write; // pull in write(str) from Print
 
 private:
-    uint8_t _idx; // TinyUSB CDC Interface Index
+  uint8_t _idx; // TinyUSB CDC Interface Index
 };
 
 #endif

--- a/src/arduino/cdc/Adafruit_USBH_CDC.h
+++ b/src/arduino/cdc/Adafruit_USBH_CDC.h
@@ -1,0 +1,71 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Ha Thach (tinyusb.org) for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef ADAFRUIT_USBH_CDC_H_
+#define ADAFRUIT_USBH_CDC_H_
+
+#include "Stream.h"
+
+class Adafruit_USBH_CDC : public Stream {
+public:
+    Adafruit_USBH_CDC(void);
+
+    // Init/Bind to an specific cdc interface
+    void begin(uint8_t idx = 0);
+
+    // unbind cdc interface
+    void end(void);
+
+    // Get index of cdc interface
+    uint8_t getIndex(void) { return _idx; }
+
+    // If cdc is mounted
+    operator bool();
+
+    // if cdc's DTR is asserted
+    bool connected(void);
+
+    //------------- Stream API -------------//
+    virtual int available(void);
+    virtual int peek(void);
+
+    virtual int read(void);
+    size_t read(uint8_t *buffer, size_t size);
+
+    virtual void flush(void);
+    virtual size_t write(uint8_t ch);
+
+    virtual size_t write(const uint8_t *buffer, size_t size);
+    size_t write(const char *buffer, size_t size) {
+      return write((const uint8_t *)buffer, size);
+    }
+
+    virtual int availableForWrite(void);
+    using Print::write; // pull in write(str) from Print
+
+private:
+    uint8_t _idx; // TinyUSB CDC Interface Index
+};
+
+#endif

--- a/src/arduino/ports/rp2040/tusb_config_rp2040.h
+++ b/src/arduino/ports/rp2040/tusb_config_rp2040.h
@@ -116,18 +116,18 @@ extern int serial1_printf(const char *__restrict __format, ...);
 #define CFG_TUH_CDC 1
 
 // RX & TX fifo size
-#define CFG_TUH_CDC_RX_BUFSIZE    128
-#define CFG_TUH_CDC_TX_BUFSIZE    128
-
+#define CFG_TUH_CDC_RX_BUFSIZE 128
+#define CFG_TUH_CDC_TX_BUFSIZE 128
 
 // Set Line Control state on enumeration/mounted:
 // DTR ( bit 0), RTS (bit 1)
-#define CFG_TUH_CDC_LINE_CONTROL_ON_ENUM    0x03
+#define CFG_TUH_CDC_LINE_CONTROL_ON_ENUM 0x03
 
 // Set Line Coding on enumeration/mounted, value for cdc_line_coding_t
 // bit rate = 115200, 1 stop bit, no parity, 8 bit data width
-// This need https://github.com/sekigon-gonnoc/Pico-PIO-USB/pull/58 to be merged first
-// #define CFG_TUH_CDC_LINE_CODING_ON_ENUM   { 115200, CDC_LINE_CONDING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }
+// This need https://github.com/sekigon-gonnoc/Pico-PIO-USB/pull/58 to be merged
+// first #define CFG_TUH_CDC_LINE_CODING_ON_ENUM   { 115200,
+// CDC_LINE_CONDING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }
 
 #ifdef __cplusplus
 }

--- a/src/arduino/ports/rp2040/tusb_config_rp2040.h
+++ b/src/arduino/ports/rp2040/tusb_config_rp2040.h
@@ -115,6 +115,11 @@ extern int serial1_printf(const char *__restrict __format, ...);
 // Number of CDC interfaces
 #define CFG_TUH_CDC 1
 
+// RX & TX fifo size
+#define CFG_TUH_CDC_RX_BUFSIZE    128
+#define CFG_TUH_CDC_TX_BUFSIZE    128
+
+
 // Set Line Control state on enumeration/mounted:
 // DTR ( bit 0), RTS (bit 1)
 #define CFG_TUH_CDC_LINE_CONTROL_ON_ENUM    0x03

--- a/src/arduino/ports/rp2040/tusb_config_rp2040.h
+++ b/src/arduino/ports/rp2040/tusb_config_rp2040.h
@@ -97,15 +97,32 @@ extern int serial1_printf(const char *__restrict __format, ...);
 // Size of buffer to hold descriptors and other data used for enumeration
 #define CFG_TUH_ENUMERATION_BUFSIZE 256
 
+// Number of hub devices
 #define CFG_TUH_HUB 1
+
 // max device support (excluding hub device)
 #define CFG_TUH_DEVICE_MAX (CFG_TUH_HUB ? 4 : 1) // hub typically has 4 ports
 
 // Enable tuh_edpt_xfer() API
 //#define CFG_TUH_API_EDPT_XFER       1
 
+// Number of mass storage
 #define CFG_TUH_MSC 1
+
+// Number of HIDs
 #define CFG_TUH_HID 4
+
+// Number of CDC interfaces
+#define CFG_TUH_CDC 1
+
+// Set Line Control state on enumeration/mounted:
+// DTR ( bit 0), RTS (bit 1)
+#define CFG_TUH_CDC_LINE_CONTROL_ON_ENUM    0x03
+
+// Set Line Coding on enumeration/mounted, value for cdc_line_coding_t
+// bit rate = 115200, 1 stop bit, no parity, 8 bit data width
+// This need https://github.com/sekigon-gonnoc/Pico-PIO-USB/pull/58 to be merged first
+// #define CFG_TUH_CDC_LINE_CODING_ON_ENUM   { 115200, CDC_LINE_CONDING_STOP_BITS_1, CDC_LINE_CODING_PARITY_NONE, 8 }
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Add initial host cdc support with Adafruit_USBH_CDC class.
- Add DualRole/serial_host_bridge example to demonstrate how to use cdc host.