### PR TITLE
Add additional example for Tremors using a logarithm filter

### DIFF
--- a/examples/DualRole/HID/hid_mouse_log_filter/hid_mouse_log_filter.ino
+++ b/examples/DualRole/HID/hid_mouse_log_filter/hid_mouse_log_filter.ino
@@ -1,0 +1,214 @@
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2023 Bill Binko for Adafruit Industries
+ Based on tremor_filter example by Thach Ha
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
+
+
+/* This example demonstrates use of both device and host, where
+ * - Device run on native usb controller (controller0)
+ * - Host run on bit-banging 2 GPIOs with the help of Pico-PIO-USB library (controller1)
+ *
+ * Example sketch receive keyboard report from host interface (from e.g consumer keyboard)
+ * and remap it to another key and send it via device interface (to PC). For simplicity,
+ * this example only toggle shift key to the report, effectively remap:
+ * - all character key <-> upper case
+ * - number <-> its symbol (with shift)
+ *
+ * Requirements:
+ * - [Pico-PIO-USB](https://github.com/sekigon-gonnoc/Pico-PIO-USB) library
+ * - 2 consecutive GPIOs: D+ is defined by PIN_PIO_USB_HOST_DP, D- = D+ +1
+ * - Provide VBus (5v) and GND for peripheral
+ * - CPU Speed must be either 120 or 240 Mhz. Selected via "Menu -> CPU Speed"
+ */
+
+// pio-usb is required for rp2040 host
+#include "pio_usb.h"
+#include "Adafruit_TinyUSB.h"
+#include <math.h>
+
+// Pin D+ for host, D- = D+ + 1
+#ifndef PIN_USB_HOST_DP
+#define PIN_USB_HOST_DP  16
+#endif
+
+// Pin for enabling Host VBUS. comment out if not used
+#ifndef PIN_5V_EN
+#define PIN_5V_EN        18
+#endif
+
+#ifndef PIN_5V_EN_STATE
+#define PIN_5V_EN_STATE  1
+#endif
+
+// Language ID: English
+#define LANGUAGE_ID 0x0409
+
+// USB Host object
+Adafruit_USBH_Host USBHost;
+
+// HID report descriptor using TinyUSB's template
+// Single Report (no ID) descriptor
+uint8_t const desc_hid_report[] =
+{
+  TUD_HID_REPORT_DESC_MOUSE()
+};
+
+// USB HID object. For ESP32 these values cannot be changed after this declaration
+// desc report, desc len, protocol, interval, use out endpoint
+Adafruit_USBD_HID usb_hid(desc_hid_report, sizeof(desc_hid_report), HID_ITF_PROTOCOL_MOUSE, 2, false);
+
+/* Adjustable parameters for the log_filter() method.  Adjust for each user (would be ideal to have this 
+ *  adjustable w/o recompiling
+ */
+#define PRESCALE 8.0  // Must be > 0, Higher numbers increase rate of attenuation
+#define POSTSCALE 1.5 // Must be > 0, Higher numbers compensate for PRESCALE attenuation
+#define DEADZONE 1.0  // Must be > 1, Movements < this magnitude will not be filtered
+
+
+//--------------------------------------------------------------------+
+// Setup and Loop on Core0
+//--------------------------------------------------------------------+
+
+void setup()
+{
+  Serial.begin(115200);
+  usb_hid.begin();
+
+  //while ( !Serial ) delay(10);   // wait for native usb
+  Serial.println("ATMakers Logarithm Tremor Filter Example");
+}
+
+void loop()
+{
+  Serial.flush();
+}
+
+//--------------------------------------------------------------------+
+// Setup and Loop on Core1
+//--------------------------------------------------------------------+
+
+void setup1() {
+  //while ( !Serial ) delay(10);   // wait for native usb
+  Serial.println("Core1 setup to run TinyUSB host with pio-usb");
+
+  // Check for CPU frequency, must be multiple of 120Mhz for bit-banging USB
+  uint32_t cpu_hz = clock_get_hz(clk_sys);
+  if ( cpu_hz != 120000000UL && cpu_hz != 240000000UL ) {
+    while ( !Serial ) delay(10);   // wait for native usb
+    Serial.printf("Error: CPU Clock = %lu, PIO USB require CPU clock must be multiple of 120 Mhz\r\n", cpu_hz);
+    Serial.printf("Change your CPU Clock to either 120 or 240 Mhz in Menu->CPU Speed \r\n");
+    while(1) delay(1);
+  }
+
+#ifdef PIN_5V_EN
+  pinMode(PIN_5V_EN, OUTPUT);
+  digitalWrite(PIN_5V_EN, PIN_5V_EN_STATE);
+#endif
+
+  pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
+  pio_cfg.pin_dp = PIN_USB_HOST_DP;
+  USBHost.configure_pio_usb(1, &pio_cfg);
+
+  // run host stack on controller (rhport) 1
+  // Note: For rp2040 pico-pio-usb, calling USBHost.begin() on core1 will have most of the
+  // host bit-banging processing works done in core1 to free up core0 for other works
+  USBHost.begin(1);
+}
+
+void loop1()
+{
+  USBHost.task();
+}
+
+
+extern "C"
+{
+
+// Invoked when device with hid interface is mounted
+// Report descriptor is also available for use.
+// tuh_hid_parse_report_descriptor() can be used to parse common/simple enough
+// descriptor. Note: if report descriptor length > CFG_TUH_ENUMERATION_BUFSIZE,
+// it will be skipped therefore report_desc = NULL, desc_len = 0
+void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const *desc_report, uint16_t desc_len) {
+  (void) desc_report;
+  (void) desc_len;
+  uint16_t vid, pid;
+  tuh_vid_pid_get(dev_addr, &vid, &pid);
+
+  Serial.printf("HID device address = %d, instance = %d is mounted\r\n", dev_addr, instance);
+  Serial.printf("VID = %04x, PID = %04x\r\n", vid, pid);
+
+  uint8_t const itf_protocol = tuh_hid_interface_protocol(dev_addr, instance);
+  if (itf_protocol == HID_ITF_PROTOCOL_MOUSE) {
+    Serial.printf("HID Mouse\r\n");
+    if (!tuh_hid_receive_report(dev_addr, instance)) {
+      Serial.printf("Error: cannot request to receive report\r\n");
+    }
+  }
+}
+
+// Invoked when device with hid interface is un-mounted
+void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance) {
+  Serial.printf("HID device address = %d, instance = %d is unmounted\r\n", dev_addr, instance);
+}
+
+
+// Invoked when received report from device via interrupt endpoint
+void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance, uint8_t const *report, uint16_t len) {
+  filter_report((hid_mouse_report_t const *) report);
+
+  // continue to request to receive report
+  if (!tuh_hid_receive_report(dev_addr, instance)) {
+    Serial.printf("Error: cannot request to receive report\r\n");
+  }
+}
+
+} // extern C
+
+//--------------------------------------------------------------------+
+// Low pass filter Functions
+//--------------------------------------------------------------------+
+
+/*
+ * log_filter: Reduce large motions due to tremors by applying the natural log function
+ * Handles negative values and a dead zone where small values will not be adjusted
+ */
+int8_t log_filter(int8_t val)
+{
+  if (val < -1*DEADZONE)
+  {
+    return (int8_t) (-1.0 * POSTSCALE * logf(-1.0 * PRESCALE * (float)val));   
+  }
+  else if (val > DEADZONE)
+  {
+    return (int8_t) (POSTSCALE * logf(PRESCALE * (float)val));   
+  }
+  else
+  {
+    return val;
+  }
+}
+
+/*
+ * Adjust HID report by applying log_filter
+ */
+void filter_report(hid_mouse_report_t const* report) {
+
+  int8_t old_x = report->x;
+  int8_t old_y = report->y;
+
+  hid_mouse_report_t filtered_report = *report;
+  filtered_report.x = log_filter(old_x);
+  filtered_report.y = log_filter(old_y);
+
+  //Serial.printf("%d,%d,%d,%d\n", old_x, filtered_report.x, old_y, filtered_report.y);
+  usb_hid.sendReport(0, &filtered_report, sizeof(filtered_report));
+  
+}


### PR DESCRIPTION
This filter seems to compensate for Essential Tremors better than the other.  YMMV, but I think this is a good starting point

Also, neither example sends through middle mouse, scroll wheel functions, etc.  I believe that's due to Thach's default being to use a Boot Mode Mouse, but it would be good to pass those through.  