### PR TITLE
Updating pin names for examples

### DIFF
--- a/examples/DualRole/CDC/serial_host_bridge/serial_host_bridge.ino
+++ b/examples/DualRole/CDC/serial_host_bridge/serial_host_bridge.ino
@@ -20,7 +20,7 @@
 
  * Requirements:
  * - [Pico-PIO-USB](https://github.com/sekigon-gonnoc/Pico-PIO-USB) library
- * - 2 consecutive GPIOs: D+ is defined by PIN_PIO_USB_HOST_DP, D- = D+ +1
+ * - 2 consecutive GPIOs: D+ is defined by PIN_USB_HOST_DP, D- = D+ +1
  * - Provide VBus (5v) and GND for peripheral
  * - CPU Speed must be either 120 or 240 Mhz. Selected via "Menu -> CPU Speed"
  */
@@ -32,17 +32,17 @@
 #include "Adafruit_TinyUSB.h"
 
 // Pin D+ for host, D- = D+ + 1
-#ifndef PIN_PIO_USB_HOST_DP
-#define PIN_PIO_USB_HOST_DP       20
+#ifndef PIN_USB_HOST_DP
+#define PIN_USB_HOST_DP       16
 #endif
 
 // Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_PIO_USB_HOST_VBUSEN
-#define PIN_PIO_USB_HOST_VBUSEN        22
+#ifndef PIN_5V_EN
+#define PIN_5V_EN        18
 #endif
 
-#ifndef PIN_PIO_USB_HOST_VBUSEN_STATE
-#define PIN_PIO_USB_HOST_VBUSEN_STATE  1
+#ifndef PIN_5V_EN_STATE
+#define PIN_5V_EN_STATE  1
 #endif
 
 // USB Host object
@@ -105,20 +105,20 @@ void setup1() {
     }
   }
 
-#ifdef PIN_PIO_USB_HOST_VBUSEN
-  pinMode(PIN_PIO_USB_HOST_VBUSEN, OUTPUT);
+#ifdef PIN_5V_EN
+  pinMode(PIN_5V_EN, OUTPUT);
 
   // power off first
-  digitalWrite(PIN_PIO_USB_HOST_VBUSEN, 1-PIN_PIO_USB_HOST_VBUSEN_STATE);
+  digitalWrite(PIN_5V_EN, 1-PIN_5V_EN_STATE);
   delay(1);
 
   // power on
-  digitalWrite(PIN_PIO_USB_HOST_VBUSEN, PIN_PIO_USB_HOST_VBUSEN_STATE);
+  digitalWrite(PIN_5V_EN, PIN_5V_EN_STATE);
   delay(10);
 #endif
 
   pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
-  pio_cfg.pin_dp = PIN_PIO_USB_HOST_DP;
+  pio_cfg.pin_dp = PIN_USB_HOST_DP;
   USBHost.configure_pio_usb(1, &pio_cfg);
 
   // run host stack on controller (rhport) 1

--- a/examples/DualRole/HID/hid_device_report/hid_device_report.ino
+++ b/examples/DualRole/HID/hid_device_report/hid_device_report.ino
@@ -16,7 +16,7 @@
  *
  * Requirements:
  * - [Pico-PIO-USB](https://github.com/sekigon-gonnoc/Pico-PIO-USB) library
- * - 2 consecutive GPIOs: D+ is defined by PIN_PIO_USB_HOST_DP, D- = D+ +1
+ * - 2 consecutive GPIOs: D+ is defined by PIN_USB_HOST_DP, D- = D+ +1
  * - Provide VBus (5v) and GND for peripheral
  * - CPU Speed must be either 120 or 240 Mhz. Selected via "Menu -> CPU Speed"
  */

--- a/examples/DualRole/HID/hid_remapper/hid_remapper.ino
+++ b/examples/DualRole/HID/hid_remapper/hid_remapper.ino
@@ -22,7 +22,7 @@
  *
  * Requirements:
  * - [Pico-PIO-USB](https://github.com/sekigon-gonnoc/Pico-PIO-USB) library
- * - 2 consecutive GPIOs: D+ is defined by PIN_PIO_USB_HOST_DP, D- = D+ +1
+ * - 2 consecutive GPIOs: D+ is defined by PIN_USB_HOST_DP, D- = D+ +1
  * - Provide VBus (5v) and GND for peripheral
  * - CPU Speed must be either 120 or 240 Mhz. Selected via "Menu -> CPU Speed"
  */
@@ -32,17 +32,17 @@
 #include "Adafruit_TinyUSB.h"
 
 // Pin D+ for host, D- = D+ + 1
-#ifndef PIN_PIO_USB_HOST_DP
-#define PIN_PIO_USB_HOST_DP       20
+#ifndef PIN_USB_HOST_DP
+#define PIN_USB_HOST_DP       16
 #endif
 
 // Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_PIO_USB_HOST_VBUSEN
-#define PIN_PIO_USB_HOST_VBUSEN        22
+#ifndef PIN_5V_EN
+#define PIN_5V_EN        18
 #endif
 
-#ifndef PIN_PIO_USB_HOST_VBUSEN_STATE
-#define PIN_PIO_USB_HOST_VBUSEN_STATE  1
+#ifndef PIN_5V_EN_STATE
+#define PIN_5V_EN_STATE  1
 #endif
 
 // Language ID: English
@@ -98,13 +98,13 @@ void setup1() {
     while(1) delay(1);
   }
 
-#ifdef PIN_PIO_USB_HOST_VBUSEN
-  pinMode(PIN_PIO_USB_HOST_VBUSEN, OUTPUT);
-  digitalWrite(PIN_PIO_USB_HOST_VBUSEN, PIN_PIO_USB_HOST_VBUSEN_STATE);
+#ifdef PIN_5V_EN
+  pinMode(PIN_5V_EN, OUTPUT);
+  digitalWrite(PIN_5V_EN, PIN_5V_EN_STATE);
 #endif
 
   pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
-  pio_cfg.pin_dp = PIN_PIO_USB_HOST_DP;
+  pio_cfg.pin_dp = PIN_USB_HOST_DP;
   USBHost.configure_pio_usb(1, &pio_cfg);
 
   // run host stack on controller (rhport) 1

--- a/examples/DualRole/MassStorage/msc_data_logger/msc_data_logger.ino
+++ b/examples/DualRole/MassStorage/msc_data_logger/msc_data_logger.ino
@@ -18,7 +18,7 @@
  *
  * Requirements:
  * - [Pico-PIO-USB](https://github.com/sekigon-gonnoc/Pico-PIO-USB) library
- * - 2 consecutive GPIOs: D+ is defined by PIN_PIO_USB_HOST_DP, D- = D+ +1
+ * - 2 consecutive GPIOs: D+ is defined by PIN_USB_HOST_DP, D- = D+ +1
  * - Provide VBus (5v) and GND for peripheral
  * - CPU Speed must be either 120 or 240 Mhz. Selected via "Menu -> CPU Speed"
  */
@@ -33,17 +33,17 @@
 #include "Adafruit_TinyUSB.h"
 
 // Pin D+ for host, D- = D+ + 1
-#ifndef PIN_PIO_USB_HOST_DP
-#define PIN_PIO_USB_HOST_DP       20
+#ifndef PIN_USB_HOST_DP
+#define PIN_USB_HOST_DP       16
 #endif
 
 // Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_PIO_USB_HOST_VBUSEN
-#define PIN_PIO_USB_HOST_VBUSEN        22
+#ifndef PIN_5V_EN
+#define PIN_5V_EN        18
 #endif
 
-#ifndef PIN_PIO_USB_HOST_VBUSEN_STATE
-#define PIN_PIO_USB_HOST_VBUSEN_STATE  1
+#ifndef PIN_5V_EN_STATE
+#define PIN_5V_EN_STATE  1
 #endif
 
 
@@ -126,13 +126,13 @@ void setup1() {
     }
   }
 
-#ifdef PIN_PIO_USB_HOST_VBUSEN
-  pinMode(PIN_PIO_USB_HOST_VBUSEN, OUTPUT);
-  digitalWrite(PIN_PIO_USB_HOST_VBUSEN, PIN_PIO_USB_HOST_VBUSEN_STATE);
+#ifdef PIN_5V_EN
+  pinMode(PIN_5V_EN, OUTPUT);
+  digitalWrite(PIN_5V_EN, PIN_5V_EN_STATE);
 #endif
 
   pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
-  pio_cfg.pin_dp = PIN_PIO_USB_HOST_DP;
+  pio_cfg.pin_dp = PIN_USB_HOST_DP;
   USBHost.configure_pio_usb(1, &pio_cfg);
 
   // run host stack on controller (rhport) 1

--- a/examples/DualRole/MassStorage/msc_file_explorer/msc_file_explorer.ino
+++ b/examples/DualRole/MassStorage/msc_file_explorer/msc_file_explorer.ino
@@ -16,7 +16,7 @@
  *
  * Requirements:
  * - [Pico-PIO-USB](https://github.com/sekigon-gonnoc/Pico-PIO-USB) library
- * - 2 consecutive GPIOs: D+ is defined by PIN_PIO_USB_HOST_DP, D- = D+ +1
+ * - 2 consecutive GPIOs: D+ is defined by PIN_USB_HOST_DP, D- = D+ +1
  * - Provide VBus (5v) and GND for peripheral
  * - CPU Speed must be either 120 or 240 Mhz. Selected via "Menu -> CPU Speed"
  */
@@ -31,17 +31,17 @@
 #include "Adafruit_TinyUSB.h"
 
 // Pin D+ for host, D- = D+ + 1
-#ifndef PIN_PIO_USB_HOST_DP
-#define PIN_PIO_USB_HOST_DP       20
+#ifndef PIN_USB_HOST_DP
+#define PIN_USB_HOST_DP       16
 #endif
 
 // Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_PIO_USB_HOST_VBUSEN
-#define PIN_PIO_USB_HOST_VBUSEN        22
+#ifndef PIN_5V_EN
+#define PIN_5V_EN        18
 #endif
 
-#ifndef PIN_PIO_USB_HOST_VBUSEN_STATE
-#define PIN_PIO_USB_HOST_VBUSEN_STATE  1
+#ifndef PIN_5V_EN_STATE
+#define PIN_5V_EN_STATE  1
 #endif
 
 // USB Host object
@@ -93,13 +93,13 @@ void setup1() {
     }
   }
 
-#ifdef PIN_PIO_USB_HOST_VBUSEN
-  pinMode(PIN_PIO_USB_HOST_VBUSEN, OUTPUT);
-  digitalWrite(PIN_PIO_USB_HOST_VBUSEN, PIN_PIO_USB_HOST_VBUSEN_STATE);
+#ifdef PIN_5V_EN
+  pinMode(PIN_5V_EN, OUTPUT);
+  digitalWrite(PIN_5V_EN, PIN_5V_EN_STATE);
 #endif
 
   pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
-  pio_cfg.pin_dp = PIN_PIO_USB_HOST_DP;
+  pio_cfg.pin_dp = PIN_USB_HOST_DP;
   USBHost.configure_pio_usb(1, &pio_cfg);
 
   // run host stack on controller (rhport) 1

--- a/examples/DualRole/device_info_rp2040/device_info_rp2040.ino
+++ b/examples/DualRole/device_info_rp2040/device_info_rp2040.ino
@@ -16,7 +16,7 @@
  *
  * Requirements:
  * - [Pico-PIO-USB](https://github.com/sekigon-gonnoc/Pico-PIO-USB) library
- * - 2 consecutive GPIOs: D+ is defined by PIN_PIO_USB_HOST_DP, D- = D+ +1
+ * - 2 consecutive GPIOs: D+ is defined by PIN_USB_HOST_DP, D- = D+ +1
  * - Provide VBus (5v) and GND for peripheral
  * - CPU Speed must be either 120 or 240 Mhz. Selected via "Menu -> CPU Speed"
  *
@@ -46,17 +46,17 @@
 #include "Adafruit_TinyUSB.h"
 
 // Pin D+ for host, D- = D+ + 1
-#ifndef PIN_PIO_USB_HOST_DP
-#define PIN_PIO_USB_HOST_DP       20
+#ifndef PIN_USB_HOST_DP
+#define PIN_USB_HOST_DP       16
 #endif
 
 // Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_PIO_USB_HOST_VBUSEN
-#define PIN_PIO_USB_HOST_VBUSEN        22
+#ifndef PIN_5V_EN
+#define PIN_5V_EN        18
 #endif
 
-#ifndef PIN_PIO_USB_HOST_VBUSEN_STATE
-#define PIN_PIO_USB_HOST_VBUSEN_STATE  1
+#ifndef PIN_5V_EN_STATE
+#define PIN_5V_EN_STATE  1
 #endif
 
 // Language ID: English
@@ -108,13 +108,13 @@ void setup1() {
     }
   }
 
-#ifdef PIN_PIO_USB_HOST_VBUSEN
-  pinMode(PIN_PIO_USB_HOST_VBUSEN, OUTPUT);
-  digitalWrite(PIN_PIO_USB_HOST_VBUSEN, PIN_PIO_USB_HOST_VBUSEN_STATE);
+#ifdef PIN_5V_EN
+  pinMode(PIN_5V_EN, OUTPUT);
+  digitalWrite(PIN_5V_EN, PIN_5V_EN_STATE);
 #endif
 
   pio_usb_configuration_t pio_cfg = PIO_USB_DEFAULT_CONFIG;
-  pio_cfg.pin_dp = PIN_PIO_USB_HOST_DP;
+  pio_cfg.pin_dp = PIN_USB_HOST_DP;
   USBHost.configure_pio_usb(1, &pio_cfg);
 
   // run host stack on controller (rhport) 1


### PR DESCRIPTION
hihi- just updating the `ifndef` pin names to match the [board def names](https://github.com/earlephilhower/arduino-pico/pull/1367/files) in some of the examples. looks like the updated pin names are not in the newest bsp release yet so also updating pin numbers to `16`-`18`.