### PR TITLE
Add platformio compatibility

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,6 @@
+{
+    "name": "Adafruit TinyUSB Library",
+    "build": {
+        "libArchive": false
+    }
+}

--- a/library.json
+++ b/library.json
@@ -1,6 +1,7 @@
 {
     "name": "Adafruit TinyUSB Library",
     "build": {
-        "libArchive": false
+        "libArchive": false,
+        "flags": "-DUSE_TINYUSB"
     }
 }


### PR DESCRIPTION
This adds platformio compatibility, when this library is pulled as a gitsubmodule (e.g. in adafruit's nrf52 framework). More infos here: https://docs.platformio.org/en/latest/manifests/library-json/index.html

Related to my efforts of adding "real" platformio compatibility to Adafruit's nrf52 framework, see also https://github.com/adafruit/Adafruit_nRFCrypto/pull/6 .

Hoping for your feedback! 