### PR TITLE
change USBHost declaration with spi pin for esp32

### DIFF
--- a/examples/DualRole/CDC/serial_host_bridge/usbh_helper.h
+++ b/examples/DualRole/CDC/serial_host_bridge/usbh_helper.h
@@ -1,66 +1,56 @@
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2023 Ha Thach (tinyusb.org)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- * This file is part of the TinyUSB stack.
- */
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
 
 #ifndef USBH_HELPER_H
 #define USBH_HELPER_H
 
 #ifdef ARDUINO_ARCH_RP2040
-// pio-usb is required for rp2040 host
-#include "pio_usb.h"
+  // pio-usb is required for rp2040 host
+  #include "pio_usb.h"
 
-// Pin D+ for host, D- = D+ + 1
-#ifndef PIN_USB_HOST_DP
-#define PIN_USB_HOST_DP       16
-#endif
+  // Pin D+ for host, D- = D+ + 1
+  #ifndef PIN_USB_HOST_DP
+  #define PIN_USB_HOST_DP  16
+  #endif
 
-// Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_5V_EN
-#define PIN_5V_EN        18
-#endif
+  // Pin for enabling Host VBUS. comment out if not used
+  #ifndef PIN_5V_EN
+  #define PIN_5V_EN        18
+  #endif
 
-#ifndef PIN_5V_EN_STATE
-#define PIN_5V_EN_STATE  1
-#endif
+  #ifndef PIN_5V_EN_STATE
+  #define PIN_5V_EN_STATE  1
+  #endif
 #endif // ARDUINO_ARCH_RP2040
 
 #include "Adafruit_TinyUSB.h"
 
 #if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
+  // USB Host using MAX3421E: SPI, CS, INT
   #include "SPI.h"
 
-  #ifdef ARDUINO_ARCH_ESP32
-  // ESP32 specify SCK, MOSI, MISO, CS, INT
-  Adafruit_USBH_Host USBHost(36, 35, 37, 15, 14);
+  #if defined(ARDUINO_METRO_ESP32S2)
+    Adafruit_USBH_Host USBHost(&SPI, 15, 14);
   #else
-  // USB Host using MAX3421E: SPI, CS, INT
-  Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+    // Default use SPI and pin 10, 9 for CS and INT
+    Adafruit_USBH_Host USBHost(&SPI, 10, 9);
   #endif
 #else
+  // Native USB Host such as rp2040
   Adafruit_USBH_Host USBHost;
 #endif
+
+//--------------------------------------------------------------------+
+// Helper Functions
+//--------------------------------------------------------------------+
 
 #ifdef ARDUINO_ARCH_RP2040
 static void rp2040_configure_pio_usb(void) {

--- a/examples/DualRole/HID/hid_device_report/usbh_helper.h
+++ b/examples/DualRole/HID/hid_device_report/usbh_helper.h
@@ -1,66 +1,56 @@
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2023 Ha Thach (tinyusb.org)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- * This file is part of the TinyUSB stack.
- */
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
 
 #ifndef USBH_HELPER_H
 #define USBH_HELPER_H
 
 #ifdef ARDUINO_ARCH_RP2040
-// pio-usb is required for rp2040 host
-#include "pio_usb.h"
+  // pio-usb is required for rp2040 host
+  #include "pio_usb.h"
 
-// Pin D+ for host, D- = D+ + 1
-#ifndef PIN_USB_HOST_DP
-#define PIN_USB_HOST_DP       16
-#endif
+  // Pin D+ for host, D- = D+ + 1
+  #ifndef PIN_USB_HOST_DP
+  #define PIN_USB_HOST_DP  16
+  #endif
 
-// Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_5V_EN
-#define PIN_5V_EN        18
-#endif
+  // Pin for enabling Host VBUS. comment out if not used
+  #ifndef PIN_5V_EN
+  #define PIN_5V_EN        18
+  #endif
 
-#ifndef PIN_5V_EN_STATE
-#define PIN_5V_EN_STATE  1
-#endif
+  #ifndef PIN_5V_EN_STATE
+  #define PIN_5V_EN_STATE  1
+  #endif
 #endif // ARDUINO_ARCH_RP2040
 
 #include "Adafruit_TinyUSB.h"
 
 #if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
+  // USB Host using MAX3421E: SPI, CS, INT
   #include "SPI.h"
 
-  #ifdef ARDUINO_ARCH_ESP32
-  // ESP32 specify SCK, MOSI, MISO, CS, INT
-  Adafruit_USBH_Host USBHost(36, 35, 37, 15, 14);
+  #if defined(ARDUINO_METRO_ESP32S2)
+    Adafruit_USBH_Host USBHost(&SPI, 15, 14);
   #else
-  // USB Host using MAX3421E: SPI, CS, INT
-  Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+    // Default use SPI and pin 10, 9 for CS and INT
+    Adafruit_USBH_Host USBHost(&SPI, 10, 9);
   #endif
 #else
+  // Native USB Host such as rp2040
   Adafruit_USBH_Host USBHost;
 #endif
+
+//--------------------------------------------------------------------+
+// Helper Functions
+//--------------------------------------------------------------------+
 
 #ifdef ARDUINO_ARCH_RP2040
 static void rp2040_configure_pio_usb(void) {

--- a/examples/DualRole/HID/hid_mouse_log_filter/usbh_helper.h
+++ b/examples/DualRole/HID/hid_mouse_log_filter/usbh_helper.h
@@ -1,66 +1,56 @@
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2023 Ha Thach (tinyusb.org)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- * This file is part of the TinyUSB stack.
- */
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
 
 #ifndef USBH_HELPER_H
 #define USBH_HELPER_H
 
 #ifdef ARDUINO_ARCH_RP2040
-// pio-usb is required for rp2040 host
-#include "pio_usb.h"
+  // pio-usb is required for rp2040 host
+  #include "pio_usb.h"
 
-// Pin D+ for host, D- = D+ + 1
-#ifndef PIN_USB_HOST_DP
-#define PIN_USB_HOST_DP       16
-#endif
+  // Pin D+ for host, D- = D+ + 1
+  #ifndef PIN_USB_HOST_DP
+  #define PIN_USB_HOST_DP  16
+  #endif
 
-// Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_5V_EN
-#define PIN_5V_EN        18
-#endif
+  // Pin for enabling Host VBUS. comment out if not used
+  #ifndef PIN_5V_EN
+  #define PIN_5V_EN        18
+  #endif
 
-#ifndef PIN_5V_EN_STATE
-#define PIN_5V_EN_STATE  1
-#endif
+  #ifndef PIN_5V_EN_STATE
+  #define PIN_5V_EN_STATE  1
+  #endif
 #endif // ARDUINO_ARCH_RP2040
 
 #include "Adafruit_TinyUSB.h"
 
 #if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
+  // USB Host using MAX3421E: SPI, CS, INT
   #include "SPI.h"
 
-  #ifdef ARDUINO_ARCH_ESP32
-  // ESP32 specify SCK, MOSI, MISO, CS, INT
-  Adafruit_USBH_Host USBHost(36, 35, 37, 15, 14);
+  #if defined(ARDUINO_METRO_ESP32S2)
+    Adafruit_USBH_Host USBHost(&SPI, 15, 14);
   #else
-  // USB Host using MAX3421E: SPI, CS, INT
-  Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+    // Default use SPI and pin 10, 9 for CS and INT
+    Adafruit_USBH_Host USBHost(&SPI, 10, 9);
   #endif
 #else
+  // Native USB Host such as rp2040
   Adafruit_USBH_Host USBHost;
 #endif
+
+//--------------------------------------------------------------------+
+// Helper Functions
+//--------------------------------------------------------------------+
 
 #ifdef ARDUINO_ARCH_RP2040
 static void rp2040_configure_pio_usb(void) {

--- a/examples/DualRole/HID/hid_mouse_tremor_filter/usbh_helper.h
+++ b/examples/DualRole/HID/hid_mouse_tremor_filter/usbh_helper.h
@@ -1,66 +1,56 @@
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2023 Ha Thach (tinyusb.org)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- * This file is part of the TinyUSB stack.
- */
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
 
 #ifndef USBH_HELPER_H
 #define USBH_HELPER_H
 
 #ifdef ARDUINO_ARCH_RP2040
-// pio-usb is required for rp2040 host
-#include "pio_usb.h"
+  // pio-usb is required for rp2040 host
+  #include "pio_usb.h"
 
-// Pin D+ for host, D- = D+ + 1
-#ifndef PIN_USB_HOST_DP
-#define PIN_USB_HOST_DP       16
-#endif
+  // Pin D+ for host, D- = D+ + 1
+  #ifndef PIN_USB_HOST_DP
+  #define PIN_USB_HOST_DP  16
+  #endif
 
-// Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_5V_EN
-#define PIN_5V_EN        18
-#endif
+  // Pin for enabling Host VBUS. comment out if not used
+  #ifndef PIN_5V_EN
+  #define PIN_5V_EN        18
+  #endif
 
-#ifndef PIN_5V_EN_STATE
-#define PIN_5V_EN_STATE  1
-#endif
+  #ifndef PIN_5V_EN_STATE
+  #define PIN_5V_EN_STATE  1
+  #endif
 #endif // ARDUINO_ARCH_RP2040
 
 #include "Adafruit_TinyUSB.h"
 
 #if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
+  // USB Host using MAX3421E: SPI, CS, INT
   #include "SPI.h"
 
-  #ifdef ARDUINO_ARCH_ESP32
-  // ESP32 specify SCK, MOSI, MISO, CS, INT
-  Adafruit_USBH_Host USBHost(36, 35, 37, 15, 14);
+  #if defined(ARDUINO_METRO_ESP32S2)
+    Adafruit_USBH_Host USBHost(&SPI, 15, 14);
   #else
-  // USB Host using MAX3421E: SPI, CS, INT
-  Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+    // Default use SPI and pin 10, 9 for CS and INT
+    Adafruit_USBH_Host USBHost(&SPI, 10, 9);
   #endif
 #else
+  // Native USB Host such as rp2040
   Adafruit_USBH_Host USBHost;
 #endif
+
+//--------------------------------------------------------------------+
+// Helper Functions
+//--------------------------------------------------------------------+
 
 #ifdef ARDUINO_ARCH_RP2040
 static void rp2040_configure_pio_usb(void) {

--- a/examples/DualRole/HID/hid_remapper/usbh_helper.h
+++ b/examples/DualRole/HID/hid_remapper/usbh_helper.h
@@ -1,66 +1,56 @@
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2023 Ha Thach (tinyusb.org)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- * This file is part of the TinyUSB stack.
- */
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
 
 #ifndef USBH_HELPER_H
 #define USBH_HELPER_H
 
 #ifdef ARDUINO_ARCH_RP2040
-// pio-usb is required for rp2040 host
-#include "pio_usb.h"
+  // pio-usb is required for rp2040 host
+  #include "pio_usb.h"
 
-// Pin D+ for host, D- = D+ + 1
-#ifndef PIN_USB_HOST_DP
-#define PIN_USB_HOST_DP       16
-#endif
+  // Pin D+ for host, D- = D+ + 1
+  #ifndef PIN_USB_HOST_DP
+  #define PIN_USB_HOST_DP  16
+  #endif
 
-// Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_5V_EN
-#define PIN_5V_EN        18
-#endif
+  // Pin for enabling Host VBUS. comment out if not used
+  #ifndef PIN_5V_EN
+  #define PIN_5V_EN        18
+  #endif
 
-#ifndef PIN_5V_EN_STATE
-#define PIN_5V_EN_STATE  1
-#endif
+  #ifndef PIN_5V_EN_STATE
+  #define PIN_5V_EN_STATE  1
+  #endif
 #endif // ARDUINO_ARCH_RP2040
 
 #include "Adafruit_TinyUSB.h"
 
 #if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
+  // USB Host using MAX3421E: SPI, CS, INT
   #include "SPI.h"
 
-  #ifdef ARDUINO_ARCH_ESP32
-  // ESP32 specify SCK, MOSI, MISO, CS, INT
-  Adafruit_USBH_Host USBHost(36, 35, 37, 15, 14);
+  #if defined(ARDUINO_METRO_ESP32S2)
+    Adafruit_USBH_Host USBHost(&SPI, 15, 14);
   #else
-  // USB Host using MAX3421E: SPI, CS, INT
-  Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+    // Default use SPI and pin 10, 9 for CS and INT
+    Adafruit_USBH_Host USBHost(&SPI, 10, 9);
   #endif
 #else
+  // Native USB Host such as rp2040
   Adafruit_USBH_Host USBHost;
 #endif
+
+//--------------------------------------------------------------------+
+// Helper Functions
+//--------------------------------------------------------------------+
 
 #ifdef ARDUINO_ARCH_RP2040
 static void rp2040_configure_pio_usb(void) {

--- a/examples/DualRole/MassStorage/msc_data_logger/usbh_helper.h
+++ b/examples/DualRole/MassStorage/msc_data_logger/usbh_helper.h
@@ -1,66 +1,56 @@
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2023 Ha Thach (tinyusb.org)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- * This file is part of the TinyUSB stack.
- */
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
 
 #ifndef USBH_HELPER_H
 #define USBH_HELPER_H
 
 #ifdef ARDUINO_ARCH_RP2040
-// pio-usb is required for rp2040 host
-#include "pio_usb.h"
+  // pio-usb is required for rp2040 host
+  #include "pio_usb.h"
 
-// Pin D+ for host, D- = D+ + 1
-#ifndef PIN_USB_HOST_DP
-#define PIN_USB_HOST_DP       16
-#endif
+  // Pin D+ for host, D- = D+ + 1
+  #ifndef PIN_USB_HOST_DP
+  #define PIN_USB_HOST_DP  16
+  #endif
 
-// Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_5V_EN
-#define PIN_5V_EN        18
-#endif
+  // Pin for enabling Host VBUS. comment out if not used
+  #ifndef PIN_5V_EN
+  #define PIN_5V_EN        18
+  #endif
 
-#ifndef PIN_5V_EN_STATE
-#define PIN_5V_EN_STATE  1
-#endif
+  #ifndef PIN_5V_EN_STATE
+  #define PIN_5V_EN_STATE  1
+  #endif
 #endif // ARDUINO_ARCH_RP2040
 
 #include "Adafruit_TinyUSB.h"
 
 #if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
+  // USB Host using MAX3421E: SPI, CS, INT
   #include "SPI.h"
 
-  #ifdef ARDUINO_ARCH_ESP32
-  // ESP32 specify SCK, MOSI, MISO, CS, INT
-  Adafruit_USBH_Host USBHost(36, 35, 37, 15, 14);
+  #if defined(ARDUINO_METRO_ESP32S2)
+    Adafruit_USBH_Host USBHost(&SPI, 15, 14);
   #else
-  // USB Host using MAX3421E: SPI, CS, INT
-  Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+    // Default use SPI and pin 10, 9 for CS and INT
+    Adafruit_USBH_Host USBHost(&SPI, 10, 9);
   #endif
 #else
+  // Native USB Host such as rp2040
   Adafruit_USBH_Host USBHost;
 #endif
+
+//--------------------------------------------------------------------+
+// Helper Functions
+//--------------------------------------------------------------------+
 
 #ifdef ARDUINO_ARCH_RP2040
 static void rp2040_configure_pio_usb(void) {

--- a/examples/DualRole/MassStorage/msc_file_explorer/usbh_helper.h
+++ b/examples/DualRole/MassStorage/msc_file_explorer/usbh_helper.h
@@ -1,66 +1,56 @@
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2023 Ha Thach (tinyusb.org)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- * This file is part of the TinyUSB stack.
- */
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
 
 #ifndef USBH_HELPER_H
 #define USBH_HELPER_H
 
 #ifdef ARDUINO_ARCH_RP2040
-// pio-usb is required for rp2040 host
-#include "pio_usb.h"
+  // pio-usb is required for rp2040 host
+  #include "pio_usb.h"
 
-// Pin D+ for host, D- = D+ + 1
-#ifndef PIN_USB_HOST_DP
-#define PIN_USB_HOST_DP       16
-#endif
+  // Pin D+ for host, D- = D+ + 1
+  #ifndef PIN_USB_HOST_DP
+  #define PIN_USB_HOST_DP  16
+  #endif
 
-// Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_5V_EN
-#define PIN_5V_EN        18
-#endif
+  // Pin for enabling Host VBUS. comment out if not used
+  #ifndef PIN_5V_EN
+  #define PIN_5V_EN        18
+  #endif
 
-#ifndef PIN_5V_EN_STATE
-#define PIN_5V_EN_STATE  1
-#endif
+  #ifndef PIN_5V_EN_STATE
+  #define PIN_5V_EN_STATE  1
+  #endif
 #endif // ARDUINO_ARCH_RP2040
 
 #include "Adafruit_TinyUSB.h"
 
 #if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
+  // USB Host using MAX3421E: SPI, CS, INT
   #include "SPI.h"
 
-  #ifdef ARDUINO_ARCH_ESP32
-  // ESP32 specify SCK, MOSI, MISO, CS, INT
-  Adafruit_USBH_Host USBHost(36, 35, 37, 15, 14);
+  #if defined(ARDUINO_METRO_ESP32S2)
+    Adafruit_USBH_Host USBHost(&SPI, 15, 14);
   #else
-  // USB Host using MAX3421E: SPI, CS, INT
-  Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+    // Default use SPI and pin 10, 9 for CS and INT
+    Adafruit_USBH_Host USBHost(&SPI, 10, 9);
   #endif
 #else
+  // Native USB Host such as rp2040
   Adafruit_USBH_Host USBHost;
 #endif
+
+//--------------------------------------------------------------------+
+// Helper Functions
+//--------------------------------------------------------------------+
 
 #ifdef ARDUINO_ARCH_RP2040
 static void rp2040_configure_pio_usb(void) {

--- a/examples/DualRole/Simple/device_info/usbh_helper.h
+++ b/examples/DualRole/Simple/device_info/usbh_helper.h
@@ -1,66 +1,56 @@
-/*
- * The MIT License (MIT)
- *
- * Copyright (c) 2023 Ha Thach (tinyusb.org)
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- * This file is part of the TinyUSB stack.
- */
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
 
 #ifndef USBH_HELPER_H
 #define USBH_HELPER_H
 
 #ifdef ARDUINO_ARCH_RP2040
-// pio-usb is required for rp2040 host
-#include "pio_usb.h"
+  // pio-usb is required for rp2040 host
+  #include "pio_usb.h"
 
-// Pin D+ for host, D- = D+ + 1
-#ifndef PIN_USB_HOST_DP
-#define PIN_USB_HOST_DP       16
-#endif
+  // Pin D+ for host, D- = D+ + 1
+  #ifndef PIN_USB_HOST_DP
+  #define PIN_USB_HOST_DP  16
+  #endif
 
-// Pin for enabling Host VBUS. comment out if not used
-#ifndef PIN_5V_EN
-#define PIN_5V_EN        18
-#endif
+  // Pin for enabling Host VBUS. comment out if not used
+  #ifndef PIN_5V_EN
+  #define PIN_5V_EN        18
+  #endif
 
-#ifndef PIN_5V_EN_STATE
-#define PIN_5V_EN_STATE  1
-#endif
+  #ifndef PIN_5V_EN_STATE
+  #define PIN_5V_EN_STATE  1
+  #endif
 #endif // ARDUINO_ARCH_RP2040
 
 #include "Adafruit_TinyUSB.h"
 
 #if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
+  // USB Host using MAX3421E: SPI, CS, INT
   #include "SPI.h"
 
-  #ifdef ARDUINO_ARCH_ESP32
-  // ESP32 specify SCK, MOSI, MISO, CS, INT
-  Adafruit_USBH_Host USBHost(36, 35, 37, 15, 14);
+  #if defined(ARDUINO_METRO_ESP32S2)
+    Adafruit_USBH_Host USBHost(&SPI, 15, 14);
   #else
-  // USB Host using MAX3421E: SPI, CS, INT
-  Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+    // Default use SPI and pin 10, 9 for CS and INT
+    Adafruit_USBH_Host USBHost(&SPI, 10, 9);
   #endif
 #else
+  // Native USB Host such as rp2040
   Adafruit_USBH_Host USBHost;
 #endif
+
+//--------------------------------------------------------------------+
+// Helper Functions
+//--------------------------------------------------------------------+
 
 #ifdef ARDUINO_ARCH_RP2040
 static void rp2040_configure_pio_usb(void) {

--- a/src/arduino/Adafruit_USBH_Host.cpp
+++ b/src/arduino/Adafruit_USBH_Host.cpp
@@ -121,7 +121,9 @@ bool Adafruit_USBH_Host::begin(uint8_t rhport) {
   return tuh_init(rhport);
 }
 
-void Adafruit_USBH_Host::task(void) { tuh_task(); }
+void Adafruit_USBH_Host::task(uint32_t timeout_ms, bool in_isr) {
+  tuh_task_ext(timeout_ms, in_isr);
+}
 
 // Invoked when device with hid interface is mounted
 // Report descriptor is also available for use.

--- a/src/arduino/Adafruit_USBH_Host.h
+++ b/src/arduino/Adafruit_USBH_Host.h
@@ -69,7 +69,7 @@ public:
 #endif
 
   bool begin(uint8_t rhport);
-  void task(void);
+  void task(uint32_t timeout_ms = UINT32_MAX, bool in_isr = false);
 
   //------------- internal usage -------------//
   static Adafruit_USBH_Host *_instance;

--- a/src/arduino/Adafruit_USBH_Host.h
+++ b/src/arduino/Adafruit_USBH_Host.h
@@ -54,8 +54,8 @@ private:
 public:
   // constructor for using MAX3421E (host shield)
   Adafruit_USBH_Host(SPIClass *spi, int8_t cs, int8_t intr);
-  Adafruit_USBH_Host(int8_t sck, int8_t mosi, int8_t miso, int8_t cs,
-                     int8_t intr);
+  Adafruit_USBH_Host(SPIClass *spi, int8_t sck, int8_t mosi, int8_t miso,
+                     int8_t cs, int8_t intr);
 #endif
 
 public:

--- a/src/portable/analog/max3421/hcd_max3421.c
+++ b/src/portable/analog/max3421/hcd_max3421.c
@@ -438,8 +438,9 @@ bool hcd_init(uint8_t rhport) {
   reg_write(rhport, PINCTL_ADDR, PINCTL_FDUPSPI, false);
 
   // V1 is 0x01, V2 is 0x12, V3 is 0x13
-//  uint8_t const revision = reg_read(rhport, REVISION_ADDR, false);
-//  TU_LOG2_HEX(revision);
+  uint8_t const revision = reg_read(rhport, REVISION_ADDR, false);
+  TU_ASSERT(revision == 0x01 || revision == 0x12 || revision == 0x13, false);
+  TU_LOG2_HEX(revision);
 
   // reset
   reg_write(rhport, USBCTL_ADDR, USBCTL_CHIPRES, false);

--- a/tools/update-usbh_helper.py
+++ b/tools/update-usbh_helper.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import click
+import sys
+import shutil
+
+@click.command()
+@click.argument('dir', type=click.Path(), required=True)
+def main(dir):
+    """
+    This script takes a mandatory 'dir' argument, which is a path to pivot example to update for all DualRole's examples
+    """
+    sample_dir = Path(dir)
+    if not sample_dir.is_dir():
+        # add examples/DualRoles to the path
+        sample_dir = Path('examples/DualRole') / sample_dir
+        if not sample_dir.is_dir():
+            click.echo(f"The specified dir '{dir}' does not exist or is not a valid dir.")
+            sys.exit(1)
+
+    sample_file = sample_dir / 'usbh_helper.h'
+    f_list = sorted(Path('examples/DualRole').glob('**/usbh_helper.h'))
+    for f in f_list:
+        if f != sample_file:
+            click.echo(f"Updating {f}")
+            shutil.copy(sample_file, f)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- change USBHost declaration with spi pin for esp32 to make it easier to select spi hardware module