### PR TITLE
Support featherwing max3421

### DIFF
--- a/examples/DualRole/CDC/serial_host_bridge/usbh_helper.h
+++ b/examples/DualRole/CDC/serial_host_bridge/usbh_helper.h
@@ -39,9 +39,12 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
-  #else
-    // Default use SPI and pin 10, 9 for CS and INT
+  #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
+    // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+  #else
+    // default to FeatherWing USB Host MAX3421E: CS and INT are pin D11, D10
+    Adafruit_USBH_Host USBHost(&SPI, 11, 10);
   #endif
 #else
   // Native USB Host such as rp2040

--- a/examples/DualRole/CDC/serial_host_bridge/usbh_helper.h
+++ b/examples/DualRole/CDC/serial_host_bridge/usbh_helper.h
@@ -39,6 +39,8 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
+  #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32_V2)
+    Adafruit_USBH_Host USBHost(&SPI, 27, 33);
   #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
     // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);

--- a/examples/DualRole/HID/hid_device_report/usbh_helper.h
+++ b/examples/DualRole/HID/hid_device_report/usbh_helper.h
@@ -39,9 +39,12 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
-  #else
-    // Default use SPI and pin 10, 9 for CS and INT
+  #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
+    // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+  #else
+    // default to FeatherWing USB Host MAX3421E: CS and INT are pin D11, D10
+    Adafruit_USBH_Host USBHost(&SPI, 11, 10);
   #endif
 #else
   // Native USB Host such as rp2040

--- a/examples/DualRole/HID/hid_device_report/usbh_helper.h
+++ b/examples/DualRole/HID/hid_device_report/usbh_helper.h
@@ -39,6 +39,8 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
+  #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32_V2)
+    Adafruit_USBH_Host USBHost(&SPI, 27, 33);
   #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
     // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);

--- a/examples/DualRole/HID/hid_mouse_log_filter/hid_mouse_log_filter.ino
+++ b/examples/DualRole/HID/hid_mouse_log_filter/hid_mouse_log_filter.ino
@@ -57,10 +57,13 @@ void setup() {
   Serial.begin(115200);
   usb_hid.begin();
 
-#ifndef ARDUINO_ARCH_RP2040
+#if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
   // init host stack on controller (rhport) 1
   // For rp2040: this is called in core1's setup1()
   USBHost.begin(1);
+
+  // FeatherWing USB Host use MAX3421E's GPIO0 as VBUS enable (active high)
+  USBHost.max3421_writeIOPINS1(0x01, false);
 #endif
 
   //while ( !Serial ) delay(10);   // wait for native usb

--- a/examples/DualRole/HID/hid_mouse_log_filter/usbh_helper.h
+++ b/examples/DualRole/HID/hid_mouse_log_filter/usbh_helper.h
@@ -39,9 +39,12 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
-  #else
-    // Default use SPI and pin 10, 9 for CS and INT
+  #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
+    // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+  #else
+    // default to FeatherWing USB Host MAX3421E: CS and INT are pin D11, D10
+    Adafruit_USBH_Host USBHost(&SPI, 11, 10);
   #endif
 #else
   // Native USB Host such as rp2040

--- a/examples/DualRole/HID/hid_mouse_log_filter/usbh_helper.h
+++ b/examples/DualRole/HID/hid_mouse_log_filter/usbh_helper.h
@@ -39,6 +39,8 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
+  #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32_V2)
+    Adafruit_USBH_Host USBHost(&SPI, 27, 33);
   #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
     // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);

--- a/examples/DualRole/HID/hid_mouse_tremor_filter/hid_mouse_tremor_filter.ino
+++ b/examples/DualRole/HID/hid_mouse_tremor_filter/hid_mouse_tremor_filter.ino
@@ -68,10 +68,13 @@ void setup() {
   coeffs[0] = butterworth_lowpass(CUTOFF_FREQUENCY, SAMPLING_FREQUENCY);
   coeffs[1] = butterworth_lowpass(CUTOFF_FREQUENCY, SAMPLING_FREQUENCY);
 
-#ifndef ARDUINO_ARCH_RP2040
+#if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
   // init host stack on controller (rhport) 1
   // For rp2040: this is called in core1's setup1()
   USBHost.begin(1);
+
+  // FeatherWing USB Host use MAX3421E's GPIO0 as VBUS enable (active high)
+  USBHost.max3421_writeIOPINS1(0x01, false);
 #endif
 
   //while ( !Serial ) delay(10);   // wait for native usb

--- a/examples/DualRole/HID/hid_mouse_tremor_filter/usbh_helper.h
+++ b/examples/DualRole/HID/hid_mouse_tremor_filter/usbh_helper.h
@@ -39,9 +39,12 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
-  #else
-    // Default use SPI and pin 10, 9 for CS and INT
+  #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
+    // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+  #else
+    // default to FeatherWing USB Host MAX3421E: CS and INT are pin D11, D10
+    Adafruit_USBH_Host USBHost(&SPI, 11, 10);
   #endif
 #else
   // Native USB Host such as rp2040

--- a/examples/DualRole/HID/hid_mouse_tremor_filter/usbh_helper.h
+++ b/examples/DualRole/HID/hid_mouse_tremor_filter/usbh_helper.h
@@ -39,6 +39,8 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
+  #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32_V2)
+    Adafruit_USBH_Host USBHost(&SPI, 27, 33);
   #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
     // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);

--- a/examples/DualRole/HID/hid_remapper/hid_remapper.ino
+++ b/examples/DualRole/HID/hid_remapper/hid_remapper.ino
@@ -51,10 +51,13 @@ void setup() {
   Serial.begin(115200);
   usb_hid.begin();
 
-#ifndef ARDUINO_ARCH_RP2040
+#if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
   // init host stack on controller (rhport) 1
   // For rp2040: this is called in core1's setup1()
   USBHost.begin(1);
+
+  // FeatherWing USB Host use MAX3421E's GPIO0 as VBUS enable (active high)
+  USBHost.max3421_writeIOPINS1(0x01, false);
 #endif
 
   //while ( !Serial ) delay(10);   // wait for native usb

--- a/examples/DualRole/HID/hid_remapper/usbh_helper.h
+++ b/examples/DualRole/HID/hid_remapper/usbh_helper.h
@@ -39,9 +39,12 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
-  #else
-    // Default use SPI and pin 10, 9 for CS and INT
+  #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
+    // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+  #else
+    // default to FeatherWing USB Host MAX3421E: CS and INT are pin D11, D10
+    Adafruit_USBH_Host USBHost(&SPI, 11, 10);
   #endif
 #else
   // Native USB Host such as rp2040

--- a/examples/DualRole/HID/hid_remapper/usbh_helper.h
+++ b/examples/DualRole/HID/hid_remapper/usbh_helper.h
@@ -39,6 +39,8 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
+  #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32_V2)
+    Adafruit_USBH_Host USBHost(&SPI, 27, 33);
   #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
     // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);

--- a/examples/DualRole/MassStorage/msc_data_logger/msc_data_logger.ino
+++ b/examples/DualRole/MassStorage/msc_data_logger/msc_data_logger.ino
@@ -114,10 +114,13 @@ void setup() {
 
   pinMode(LED_BUILTIN, OUTPUT);
 
-#ifndef ARDUINO_ARCH_RP2040
+#if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
   // init host stack on controller (rhport) 1
   // For rp2040: this is called in core1's setup1()
   USBHost.begin(1);
+
+  // FeatherWing USB Host use MAX3421E's GPIO0 as VBUS enable (active high)
+  USBHost.max3421_writeIOPINS1(0x01, false);
 #endif
 
 #ifdef USE_FREERTOS

--- a/examples/DualRole/MassStorage/msc_data_logger/usbh_helper.h
+++ b/examples/DualRole/MassStorage/msc_data_logger/usbh_helper.h
@@ -39,9 +39,12 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
-  #else
-    // Default use SPI and pin 10, 9 for CS and INT
+  #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
+    // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+  #else
+    // default to FeatherWing USB Host MAX3421E: CS and INT are pin D11, D10
+    Adafruit_USBH_Host USBHost(&SPI, 11, 10);
   #endif
 #else
   // Native USB Host such as rp2040

--- a/examples/DualRole/MassStorage/msc_data_logger/usbh_helper.h
+++ b/examples/DualRole/MassStorage/msc_data_logger/usbh_helper.h
@@ -39,6 +39,8 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
+  #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32_V2)
+    Adafruit_USBH_Host USBHost(&SPI, 27, 33);
   #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
     // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);

--- a/examples/DualRole/MassStorage/msc_file_explorer/msc_file_explorer.ino
+++ b/examples/DualRole/MassStorage/msc_file_explorer/msc_file_explorer.ino
@@ -44,10 +44,13 @@ bool is_mounted = false;
 void setup() {
   Serial.begin(115200);
 
-#ifndef ARDUINO_ARCH_RP2040
+#if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
   // init host stack on controller (rhport) 1
   // For rp2040: this is called in core1's setup1()
   USBHost.begin(1);
+
+  // FeatherWing USB Host use MAX3421E's GPIO0 as VBUS enable (active high)
+  USBHost.max3421_writeIOPINS1(0x01, false);
 #endif
 
   // while ( !Serial ) delay(10);   // wait for native usb

--- a/examples/DualRole/MassStorage/msc_file_explorer/usbh_helper.h
+++ b/examples/DualRole/MassStorage/msc_file_explorer/usbh_helper.h
@@ -39,9 +39,12 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
-  #else
-    // Default use SPI and pin 10, 9 for CS and INT
+  #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
+    // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+  #else
+    // default to FeatherWing USB Host MAX3421E: CS and INT are pin D11, D10
+    Adafruit_USBH_Host USBHost(&SPI, 11, 10);
   #endif
 #else
   // Native USB Host such as rp2040

--- a/examples/DualRole/MassStorage/msc_file_explorer/usbh_helper.h
+++ b/examples/DualRole/MassStorage/msc_file_explorer/usbh_helper.h
@@ -39,6 +39,8 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
+  #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32_V2)
+    Adafruit_USBH_Host USBHost(&SPI, 27, 33);
   #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
     // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);

--- a/examples/DualRole/Simple/device_info/device_info.ino
+++ b/examples/DualRole/Simple/device_info/device_info.ino
@@ -68,10 +68,13 @@ dev_info_t dev_info[CFG_TUH_DEVICE_MAX] = { 0 };
 void setup() {
   Serial.begin(115200);
 
-#ifndef ARDUINO_ARCH_RP2040
+#if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
   // init host stack on controller (rhport) 1
   // For rp2040: this is called in core1's setup1()
   USBHost.begin(1);
+
+  // FeatherWing USB Host use MAX3421E's GPIO0 as VBUS enable (active high)
+  USBHost.max3421_writeIOPINS1(0x01, false);
 #endif
 
 //  while ( !Serial ) delay(10);   // wait for native usb
@@ -94,7 +97,6 @@ void loop() {
 
 //------------- Core0 -------------//
 void loop() {
-
 }
 
 //------------- Core1 -------------//

--- a/examples/DualRole/Simple/device_info/usbh_helper.h
+++ b/examples/DualRole/Simple/device_info/usbh_helper.h
@@ -39,9 +39,12 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
-  #else
-    // Default use SPI and pin 10, 9 for CS and INT
+  #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
+    // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);
+  #else
+    // default to FeatherWing USB Host MAX3421E: CS and INT are pin D11, D10
+    Adafruit_USBH_Host USBHost(&SPI, 11, 10);
   #endif
 #else
   // Native USB Host such as rp2040

--- a/examples/DualRole/Simple/device_info/usbh_helper.h
+++ b/examples/DualRole/Simple/device_info/usbh_helper.h
@@ -39,6 +39,8 @@
 
   #if defined(ARDUINO_METRO_ESP32S2)
     Adafruit_USBH_Host USBHost(&SPI, 15, 14);
+  #elif defined(ARDUINO_ADAFRUIT_FEATHER_ESP32_V2)
+    Adafruit_USBH_Host USBHost(&SPI, 27, 33);
   #elif defined(ARDUINO_METRO_ESP32S3) || defined(ADAFRUIT_METRO_M4_EXPRESS) || defined(ADAFRUIT_METRO_M0_EXPRESS)
     // For Metro shape CS and INT are pin 10, 9 (host shield default)
     Adafruit_USBH_Host USBHost(&SPI, 10, 9);

--- a/src/arduino/Adafruit_USBH_Host.cpp
+++ b/src/arduino/Adafruit_USBH_Host.cpp
@@ -27,7 +27,6 @@
 #include "arduino/ports/esp32/tusb_config_esp32.h"
 #include "driver/gpio.h"
 #include <Arduino.h>
-#define MSBFIRST SPI_MSBFIRST
 #endif
 
 #include "tusb_option.h"

--- a/src/arduino/Adafruit_USBH_Host.cpp
+++ b/src/arduino/Adafruit_USBH_Host.cpp
@@ -40,7 +40,7 @@ Adafruit_USBH_Host *Adafruit_USBH_Host::_instance = NULL;
 
 Adafruit_USBH_Host::Adafruit_USBH_Host(void) {
   Adafruit_USBH_Host::_instance = this;
-
+  _rhport = 0;
 #if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
   _spi = NULL;
   _cs = _intr = _sck = _mosi = _miso = -1;
@@ -48,6 +48,15 @@ Adafruit_USBH_Host::Adafruit_USBH_Host(void) {
 }
 
 #if defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421
+
+// API to read MAX3421's register. Implemented by TinyUSB
+extern "C" uint8_t tuh_max3421_reg_read(uint8_t rhport, uint8_t reg,
+                                        bool in_isr);
+
+// API to write MAX3421's register. Implemented by TinyUSB
+extern "C" bool tuh_max3421_reg_write(uint8_t rhport, uint8_t reg, uint8_t data,
+                                      bool in_isr);
+
 static void max3421_isr(void);
 
 #if defined(ARDUINO_ARCH_ESP32)
@@ -57,6 +66,7 @@ static void max3421_intr_task(void *param);
 
 Adafruit_USBH_Host::Adafruit_USBH_Host(SPIClass *spi, int8_t cs, int8_t intr) {
   Adafruit_USBH_Host::_instance = this;
+  _rhport = 0;
   _spi = spi;
   _cs = cs;
   _intr = intr;
@@ -66,6 +76,7 @@ Adafruit_USBH_Host::Adafruit_USBH_Host(SPIClass *spi, int8_t cs, int8_t intr) {
 Adafruit_USBH_Host::Adafruit_USBH_Host(SPIClass *spi, int8_t sck, int8_t mosi,
                                        int8_t miso, int8_t cs, int8_t intr) {
   Adafruit_USBH_Host::_instance = this;
+  _rhport = 0;
   _spi = spi;
   _cs = cs;
   _intr = intr;
@@ -73,6 +84,16 @@ Adafruit_USBH_Host::Adafruit_USBH_Host(SPIClass *spi, int8_t sck, int8_t mosi,
   _mosi = mosi;
   _miso = miso;
 }
+
+uint8_t Adafruit_USBH_Host::max3421_readRegister(uint8_t reg, bool in_isr) {
+  return tuh_max3421_reg_read(_rhport, reg, in_isr);
+}
+
+bool Adafruit_USBH_Host::max3421_writeRegister(uint8_t reg, uint8_t data,
+                                               bool in_isr) {
+  return tuh_max3421_reg_write(_rhport, reg, data, in_isr);
+}
+
 #endif
 
 bool Adafruit_USBH_Host::configure(uint8_t rhport, uint32_t cfg_id,
@@ -118,6 +139,7 @@ bool Adafruit_USBH_Host::begin(uint8_t rhport) {
   attachInterrupt(_intr, max3421_isr, FALLING);
 #endif
 
+  _rhport = rhport;
   return tuh_init(rhport);
 }
 

--- a/src/arduino/Adafruit_USBH_Host.cpp
+++ b/src/arduino/Adafruit_USBH_Host.cpp
@@ -26,6 +26,7 @@
 #ifdef ARDUINO_ARCH_ESP32
 #include "arduino/ports/esp32/tusb_config_esp32.h"
 #include "driver/gpio.h"
+#include <Arduino.h>
 #define MSBFIRST SPI_MSBFIRST
 #endif
 
@@ -123,15 +124,13 @@ bool Adafruit_USBH_Host::begin(uint8_t rhport) {
 #ifdef ARDUINO_ARCH_ESP32
   // ESP32 SPI assign pins when begin() of declaration as standard API
   _spi->begin(_sck, _miso, _mosi, -1);
-#else
-  _spi->begin();
-#endif
 
-#ifdef ARDUINO_ARCH_ESP32
   // Create an task for executing interrupt handler in thread mode
   max3421_intr_sem = xSemaphoreCreateBinary();
   xTaskCreateUniversal(max3421_intr_task, "max3421 intr", 2048, NULL, 5, NULL,
                        ARDUINO_RUNNING_CORE);
+#else
+  _spi->begin();
 #endif
 
   // Interrupt pin

--- a/src/arduino/Adafruit_USBH_Host.h
+++ b/src/arduino/Adafruit_USBH_Host.h
@@ -56,6 +56,17 @@ public:
   Adafruit_USBH_Host(SPIClass *spi, int8_t cs, int8_t intr);
   Adafruit_USBH_Host(SPIClass *spi, int8_t sck, int8_t mosi, int8_t miso,
                      int8_t cs, int8_t intr);
+
+  uint8_t max3421_readRegister(uint8_t reg, bool in_isr);
+  bool max3421_writeRegister(uint8_t reg, uint8_t data, bool in_isr);
+  bool max3421_writeIOPINS1(uint8_t data, bool in_isr) {
+    enum { IOPINS1_ADDR = 20u << 3 }; // 0xA0
+    return max3421_writeRegister(IOPINS1_ADDR, data, in_isr);
+  }
+  bool max3421_writeIOPINS2(uint8_t data, bool in_isr) {
+    enum { IOPINS2_ADDR = 21u << 3 }; // 0xA8
+    return max3421_writeRegister(IOPINS2_ADDR, data, in_isr);
+  }
 #endif
 
 public:
@@ -75,6 +86,8 @@ public:
   static Adafruit_USBH_Host *_instance;
 
 private:
+  uint8_t _rhport;
+
   friend void tuh_max3421_spi_cs_api(uint8_t rhport, bool active);
   friend bool tuh_max3421_spi_xfer_api(uint8_t rhport, uint8_t const *tx_buf,
                                        uint8_t *rx_buf, size_t xfer_bytes);

--- a/src/arduino/ports/esp32/tusb_config_esp32.h
+++ b/src/arduino/ports/esp32/tusb_config_esp32.h
@@ -63,14 +63,6 @@ extern "C" {
 // with no OTG USB MCU such as eps32, c3 etc...
 //--------------------------------------------------------------------
 
-#ifndef CFG_TUSB_OS
-#define CFG_TUSB_OS OPT_OS_FREERTOS
-
-// clang-format off
-#define CFG_TUSB_OS_INC_PATH freertos/
-// clang-format on
-#endif
-
 // #ifndef CFG_TUSB_DEBUG
 // #define CFG_TUSB_DEBUG 0
 // #endif

--- a/src/arduino/ports/esp32/tusb_config_esp32.h
+++ b/src/arduino/ports/esp32/tusb_config_esp32.h
@@ -57,6 +57,20 @@ extern "C" {
 #define CFG_TUH_LOG_LEVEL 2
 #endif
 
+//--------------------------------------------------------------------
+// COMMON CONFIGURATION
+// Note: it is possible to use tinyusb + max3421e as host controller
+// with no OTG USB MCU such as eps32, c3 etc...
+//--------------------------------------------------------------------
+
+#ifndef CFG_TUSB_OS
+#define CFG_TUSB_OS OPT_OS_FREERTOS
+
+// clang-format off
+#define CFG_TUSB_OS_INC_PATH freertos/
+// clang-format on
+#endif
+
 // #ifndef CFG_TUSB_DEBUG
 // #define CFG_TUSB_DEBUG 0
 // #endif

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -42,7 +42,11 @@
   // Note: when compiling core Arduino IDEs will include tusb_config.h in the BSP
   // sdk/include/arduino_tinyusb/include. While compiling .c file in this library this
   // file will be used instead. For consistency: include the one in BSP here as well
-  #include "../../arduino_tinyusb/include/tusb_config.h"
+  #if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+    #include "../../arduino_tinyusb/include/tusb_config.h"
+  #else
+    #include "arduino/ports/esp32/tusb_config_esp32.h"
+  #endif
 
   // Note: For platformio prioritize this file over the one in BSP in all cases
 

--- a/src/tusb_config.h
+++ b/src/tusb_config.h
@@ -42,9 +42,15 @@
   // Note: when compiling core Arduino IDEs will include tusb_config.h in the BSP
   // sdk/include/arduino_tinyusb/include. While compiling .c file in this library this
   // file will be used instead. For consistency: include the one in BSP here as well
+  #include "sdkconfig.h"
   #if CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
     #include "../../arduino_tinyusb/include/tusb_config.h"
   #else
+    #define CFG_TUSB_OS OPT_OS_FREERTOS
+    // clang-format off
+    #define CFG_TUSB_OS_INC_PATH freertos/
+    // clang-format on
+
     #include "arduino/ports/esp32/tusb_config_esp32.h"
   #endif
 


### PR DESCRIPTION
Add support for featherwing USB host with max3421e
- add max3421_readRegister() max3421_readRegister(), max3421_writeIOPINS1(), max3421_writeIOPINS2() to usbhost with max3421
- update examples to work with featherwing usb host max3421, added max3421's GPIO0 pull up (VBUS enable) after host init
- Update tinyusb to also support non-OTG MCU such as esp32 (not tested with c3, c6 etc..)
- Tested with feather m0, m4, nrf52840, esp32s2, esp32s3, esp32 v2

@ladyada 