### PR TITLE
Add Video class support

### DIFF
--- a/examples/Video/video_capture/usb_descriptors.h
+++ b/examples/Video/video_capture/usb_descriptors.h
@@ -1,0 +1,161 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Jerzy Kasenbreg
+ * Copyright (c) 2021 Koji KITAYAMA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _USB_DESCRIPTORS_H_
+#define _USB_DESCRIPTORS_H_
+
+/* Time stamp base clock. It is a deprecated parameter. */
+#define UVC_CLOCK_FREQUENCY    27000000
+/* video capture path */
+#define UVC_ENTITY_CAP_INPUT_TERMINAL  0x01
+#define UVC_ENTITY_CAP_OUTPUT_TERMINAL 0x02
+
+#define FRAME_WIDTH   128
+#define FRAME_HEIGHT  96
+#define FRAME_RATE    10
+
+enum {
+  ITF_NUM_VIDEO_CONTROL,
+  ITF_NUM_VIDEO_STREAMING,
+  ITF_NUM_TOTAL
+};
+
+#define TUD_VIDEO_CAPTURE_DESC_UNCOMPR_LEN (\
+    TUD_VIDEO_DESC_IAD_LEN\
+    /* control */\
+    + TUD_VIDEO_DESC_STD_VC_LEN\
+    + (TUD_VIDEO_DESC_CS_VC_LEN + 1/*bInCollection*/)\
+    + TUD_VIDEO_DESC_CAMERA_TERM_LEN\
+    + TUD_VIDEO_DESC_OUTPUT_TERM_LEN\
+    /* Interface 1, Alternate 0 */\
+    + TUD_VIDEO_DESC_STD_VS_LEN\
+    + (TUD_VIDEO_DESC_CS_VS_IN_LEN + 1/*bNumFormats x bControlSize*/)\
+    + TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR_LEN\
+    + TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT_LEN\
+    + TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING_LEN\
+    /* Interface 1, Alternate 1 */\
+    + TUD_VIDEO_DESC_STD_VS_LEN\
+    + 7/* Endpoint */\
+  )
+
+#define TUD_VIDEO_CAPTURE_DESC_MJPEG_LEN (\
+    TUD_VIDEO_DESC_IAD_LEN\
+    /* control */\
+    + TUD_VIDEO_DESC_STD_VC_LEN\
+    + (TUD_VIDEO_DESC_CS_VC_LEN + 1/*bInCollection*/)\
+    + TUD_VIDEO_DESC_CAMERA_TERM_LEN\
+    + TUD_VIDEO_DESC_OUTPUT_TERM_LEN\
+    /* Interface 1, Alternate 0 */\
+    + TUD_VIDEO_DESC_STD_VS_LEN\
+    + (TUD_VIDEO_DESC_CS_VS_IN_LEN + 1/*bNumFormats x bControlSize*/)\
+    + TUD_VIDEO_DESC_CS_VS_FMT_MJPEG_LEN\
+    + TUD_VIDEO_DESC_CS_VS_FRM_MJPEG_CONT_LEN\
+    + TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING_LEN\
+    /* Interface 1, Alternate 1 */\
+    + TUD_VIDEO_DESC_STD_VS_LEN\
+    + 7/* Endpoint */\
+  )
+
+#define TUD_VIDEO_CAPTURE_DESC_UNCOMPR_BULK_LEN (\
+    TUD_VIDEO_DESC_IAD_LEN\
+    /* control */\
+    + TUD_VIDEO_DESC_STD_VC_LEN\
+    + (TUD_VIDEO_DESC_CS_VC_LEN + 1/*bInCollection*/)\
+    + TUD_VIDEO_DESC_CAMERA_TERM_LEN\
+    + TUD_VIDEO_DESC_OUTPUT_TERM_LEN\
+    /* Interface 1, Alternate 0 */\
+    + TUD_VIDEO_DESC_STD_VS_LEN\
+    + (TUD_VIDEO_DESC_CS_VS_IN_LEN + 1/*bNumFormats x bControlSize*/)\
+    + TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR_LEN\
+    + TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT_LEN\
+    + TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING_LEN\
+    + 7/* Endpoint */\
+  )
+
+#define TUD_VIDEO_CAPTURE_DESC_MJPEG_BULK_LEN (\
+    TUD_VIDEO_DESC_IAD_LEN\
+    /* control */\
+    + TUD_VIDEO_DESC_STD_VC_LEN\
+    + (TUD_VIDEO_DESC_CS_VC_LEN + 1/*bInCollection*/)\
+    + TUD_VIDEO_DESC_CAMERA_TERM_LEN\
+    + TUD_VIDEO_DESC_OUTPUT_TERM_LEN\
+    /* Interface 1, Alternate 0 */\
+    + TUD_VIDEO_DESC_STD_VS_LEN\
+    + (TUD_VIDEO_DESC_CS_VS_IN_LEN + 1/*bNumFormats x bControlSize*/)\
+    + TUD_VIDEO_DESC_CS_VS_FMT_MJPEG_LEN\
+    + TUD_VIDEO_DESC_CS_VS_FRM_MJPEG_CONT_LEN\
+    + TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING_LEN\
+    + 7/* Endpoint */\
+  )
+
+/* Windows support YUY2 and NV12
+ * https://docs.microsoft.com/en-us/windows-hardware/drivers/stream/usb-video-class-driver-overview */
+
+#define TUD_VIDEO_DESC_CS_VS_FMT_YUY2(_fmtidx, _numfmtdesc, _frmidx, _asrx, _asry, _interlace, _cp) \
+  TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR(_fmtidx, _numfmtdesc, TUD_VIDEO_GUID_YUY2, 16, _frmidx, _asrx, _asry, _interlace, _cp)
+#define TUD_VIDEO_DESC_CS_VS_FMT_NV12(_fmtidx, _numfmtdesc, _frmidx, _asrx, _asry, _interlace, _cp) \
+  TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR(_fmtidx, _numfmtdesc, TUD_VIDEO_GUID_NV12, 12, _frmidx, _asrx, _asry, _interlace, _cp)
+#define TUD_VIDEO_DESC_CS_VS_FMT_M420(_fmtidx, _numfmtdesc, _frmidx, _asrx, _asry, _interlace, _cp) \
+  TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR(_fmtidx, _numfmtdesc, TUD_VIDEO_GUID_M420, 12, _frmidx, _asrx, _asry, _interlace, _cp)
+#define TUD_VIDEO_DESC_CS_VS_FMT_I420(_fmtidx, _numfmtdesc, _frmidx, _asrx, _asry, _interlace, _cp) \
+  TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR(_fmtidx, _numfmtdesc, TUD_VIDEO_GUID_I420, 12, _frmidx, _asrx, _asry, _interlace, _cp)
+
+
+#define TUD_VIDEO_CAPTURE_DESCRIPTOR_UNCOMPR_BULK(_stridx, _epin, _width, _height, _fps, _epsize) \
+  TUD_VIDEO_DESC_IAD(ITF_NUM_VIDEO_CONTROL, /* 2 Interfaces */ 0x02, _stridx), \
+  /* Video control 0 */ \
+  TUD_VIDEO_DESC_STD_VC(ITF_NUM_VIDEO_CONTROL, 0, _stridx), \
+    TUD_VIDEO_DESC_CS_VC( /* UVC 1.5*/ 0x0150, \
+         /* wTotalLength - bLength */ \
+         TUD_VIDEO_DESC_CAMERA_TERM_LEN + TUD_VIDEO_DESC_OUTPUT_TERM_LEN, \
+         UVC_CLOCK_FREQUENCY, ITF_NUM_VIDEO_STREAMING), \
+      TUD_VIDEO_DESC_CAMERA_TERM(UVC_ENTITY_CAP_INPUT_TERMINAL, 0, 0,\
+                                 /*wObjectiveFocalLengthMin*/0, /*wObjectiveFocalLengthMax*/0,\
+                                 /*wObjectiveFocalLength*/0, /*bmControls*/0), \
+      TUD_VIDEO_DESC_OUTPUT_TERM(UVC_ENTITY_CAP_OUTPUT_TERMINAL, VIDEO_TT_STREAMING, 0, 1, 0), \
+  /* Video stream alt. 0 */ \
+  TUD_VIDEO_DESC_STD_VS(ITF_NUM_VIDEO_STREAMING, 0, 1, _stridx), \
+    /* Video stream header for without still image capture */ \
+    TUD_VIDEO_DESC_CS_VS_INPUT( /*bNumFormats*/1, \
+        /*wTotalLength - bLength */\
+        TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR_LEN\
+        + TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT_LEN\
+        + TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING_LEN,\
+        _epin, /*bmInfo*/0, /*bTerminalLink*/UVC_ENTITY_CAP_OUTPUT_TERMINAL, \
+        /*bStillCaptureMethod*/0, /*bTriggerSupport*/0, /*bTriggerUsage*/0, \
+        /*bmaControls(1)*/0), \
+      /* Video stream format */ \
+      TUD_VIDEO_DESC_CS_VS_FMT_YUY2(/*bFormatIndex*/1, /*bNumFrameDescriptors*/1, \
+        /*bDefaultFrameIndex*/1, 0, 0, 0, /*bCopyProtect*/0), \
+        /* Video stream frame format */ \
+        TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT(/*bFrameIndex */1, 0, _width, _height, \
+            _width * _height * 16, _width * _height * 16 * _fps, \
+            _width * _height * 16, \
+            (10000000/_fps), (10000000/_fps), (10000000/_fps)*_fps, (10000000/_fps)), \
+        TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING(VIDEO_COLOR_PRIMARIES_BT709, VIDEO_COLOR_XFER_CH_BT709, VIDEO_COLOR_COEF_SMPTE170M), \
+        TUD_VIDEO_DESC_EP_BULK(_epin, _epsize, 1)
+
+#endif

--- a/examples/Video/video_capture/usb_descriptors.h
+++ b/examples/Video/video_capture/usb_descriptors.h
@@ -33,10 +33,6 @@
 #define UVC_ENTITY_CAP_INPUT_TERMINAL  0x01
 #define UVC_ENTITY_CAP_OUTPUT_TERMINAL 0x02
 
-#define FRAME_WIDTH   128
-#define FRAME_HEIGHT  96
-#define FRAME_RATE    10
-
 enum {
   ITF_NUM_VIDEO_CONTROL,
   ITF_NUM_VIDEO_STREAMING,
@@ -128,22 +124,17 @@ enum {
   TUD_VIDEO_DESC_IAD(ITF_NUM_VIDEO_CONTROL, /* 2 Interfaces */ 0x02, _stridx), \
   /* Video control 0 */ \
   TUD_VIDEO_DESC_STD_VC(ITF_NUM_VIDEO_CONTROL, 0, _stridx), \
-    TUD_VIDEO_DESC_CS_VC( /* UVC 1.5*/ 0x0150, \
-         /* wTotalLength - bLength */ \
-         TUD_VIDEO_DESC_CAMERA_TERM_LEN + TUD_VIDEO_DESC_OUTPUT_TERM_LEN, \
-         UVC_CLOCK_FREQUENCY, ITF_NUM_VIDEO_STREAMING), \
-      TUD_VIDEO_DESC_CAMERA_TERM(UVC_ENTITY_CAP_INPUT_TERMINAL, 0, 0,\
-                                 /*wObjectiveFocalLengthMin*/0, /*wObjectiveFocalLengthMax*/0,\
-                                 /*wObjectiveFocalLength*/0, /*bmControls*/0), \
+    /* Header: UVC 1.5, wTotalLength - bLength */ \
+    TUD_VIDEO_DESC_CS_VC(0x0150, TUD_VIDEO_DESC_CAMERA_TERM_LEN + TUD_VIDEO_DESC_OUTPUT_TERM_LEN, UVC_CLOCK_FREQUENCY, ITF_NUM_VIDEO_STREAMING), \
+      /* Camera Terminal: ID, bAssocTerminal, iTerminal, focal min, max, length, bmControl */                                                                                              \
+      TUD_VIDEO_DESC_CAMERA_TERM(UVC_ENTITY_CAP_INPUT_TERMINAL, 0, 0, 0, 0, 0, 0), \
       TUD_VIDEO_DESC_OUTPUT_TERM(UVC_ENTITY_CAP_OUTPUT_TERMINAL, VIDEO_TT_STREAMING, 0, 1, 0), \
   /* Video stream alt. 0 */ \
   TUD_VIDEO_DESC_STD_VS(ITF_NUM_VIDEO_STREAMING, 0, 1, _stridx), \
     /* Video stream header for without still image capture */ \
     TUD_VIDEO_DESC_CS_VS_INPUT( /*bNumFormats*/1, \
         /*wTotalLength - bLength */\
-        TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR_LEN\
-        + TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT_LEN\
-        + TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING_LEN,\
+        TUD_VIDEO_DESC_CS_VS_FMT_UNCOMPR_LEN + TUD_VIDEO_DESC_CS_VS_FRM_UNCOMPR_CONT_LEN + TUD_VIDEO_DESC_CS_VS_COLOR_MATCHING_LEN,\
         _epin, /*bmInfo*/0, /*bTerminalLink*/UVC_ENTITY_CAP_OUTPUT_TERMINAL, \
         /*bStillCaptureMethod*/0, /*bTriggerSupport*/0, /*bTriggerUsage*/0, \
         /*bmaControls(1)*/0), \

--- a/examples/Video/video_capture/video_capture.ino
+++ b/examples/Video/video_capture/video_capture.ino
@@ -1,0 +1,32 @@
+/*********************************************************************
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ Copyright (c) 2019 Ha Thach for Adafruit Industries
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
+
+#include "Adafruit_TinyUSB.h"
+#include "usb_descriptors.h"
+
+#define FRAME_WIDTH   128
+#define FRAME_HEIGHT  96
+#define FRAME_RATE    10
+
+uint8_t const desc_video[] = {
+  TUD_VIDEO_CAPTURE_DESCRIPTOR_UNCOMPR_BULK(4, 0x80, FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE, 64)
+};
+
+Adafruit_USBD_Video usb_video(desc_video, sizeof(desc_video));
+
+void setup() {
+  Serial.begin(115200);
+  usb_video.begin();
+}
+
+void loop() {
+
+}

--- a/examples/Video/video_capture/video_capture.ino
+++ b/examples/Video/video_capture/video_capture.ino
@@ -17,7 +17,7 @@
 //--------------------------------------------------------------------+
 #define FRAME_WIDTH   128
 #define FRAME_HEIGHT  96
-#define FRAME_RATE    10
+#define FRAME_RATE    30
 
 uint8_t const desc_video[] = {
   TUD_VIDEO_CAPTURE_DESCRIPTOR_UNCOMPR_BULK(0, 0x80, FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE, 64)
@@ -41,7 +41,6 @@ static void fill_color_bar(uint8_t* buffer, unsigned start_position);
 
 void setup() {
   Serial.begin(115200);
-//  Serial.end();
   usb_video.begin();
 }
 

--- a/examples/Video/video_capture/video_capture.ino
+++ b/examples/Video/video_capture/video_capture.ino
@@ -12,21 +12,114 @@
 #include "Adafruit_TinyUSB.h"
 #include "usb_descriptors.h"
 
+//--------------------------------------------------------------------+
+//
+//--------------------------------------------------------------------+
 #define FRAME_WIDTH   128
 #define FRAME_HEIGHT  96
 #define FRAME_RATE    10
 
 uint8_t const desc_video[] = {
-  TUD_VIDEO_CAPTURE_DESCRIPTOR_UNCOMPR_BULK(4, 0x80, FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE, 64)
+  TUD_VIDEO_CAPTURE_DESCRIPTOR_UNCOMPR_BULK(0, 0x80, FRAME_WIDTH, FRAME_HEIGHT, FRAME_RATE, 64)
 };
 
 Adafruit_USBD_Video usb_video(desc_video, sizeof(desc_video));
 
+// YUY2 frame buffer
+static uint8_t frame_buffer[FRAME_WIDTH * FRAME_HEIGHT * 16 / 8];
+
+static unsigned frame_num = 0;
+static unsigned tx_busy = 0;
+static unsigned interval_ms = 1000 / FRAME_RATE;
+static unsigned start_ms = 0;
+static unsigned already_sent = 0;
+
+//--------------------------------------------------------------------+
+//
+//--------------------------------------------------------------------+
+static void fill_color_bar(uint8_t* buffer, unsigned start_position);
+
 void setup() {
   Serial.begin(115200);
+//  Serial.end();
   usb_video.begin();
 }
 
 void loop() {
+  if (!tud_video_n_streaming(0, 0)) {
+    already_sent = 0;
+    frame_num = 0;
+    return;
+  }
 
+  if (!already_sent) {
+    already_sent = 1;
+    start_ms = millis();
+    fill_color_bar(frame_buffer, frame_num);
+    tud_video_n_frame_xfer(0, 0, (void*) frame_buffer, FRAME_WIDTH * FRAME_HEIGHT * 16 / 8);
+  }
+
+  unsigned cur = millis();
+  if (cur - start_ms < interval_ms) return; // not enough time
+  if (tx_busy) return;
+  start_ms += interval_ms;
+
+  fill_color_bar(frame_buffer, frame_num);
+  tud_video_n_frame_xfer(0, 0, (void*) frame_buffer, FRAME_WIDTH * FRAME_HEIGHT * 16 / 8);
+}
+
+void tud_video_frame_xfer_complete_cb(uint_fast8_t ctl_idx, uint_fast8_t stm_idx) {
+  (void) ctl_idx;
+  (void) stm_idx;
+  tx_busy = 0;
+  /* flip buffer */
+  ++frame_num;
+}
+
+int tud_video_commit_cb(uint_fast8_t ctl_idx, uint_fast8_t stm_idx,
+                        video_probe_and_commit_control_t const* parameters) {
+  (void) ctl_idx;
+  (void) stm_idx;
+  /* convert unit to ms from 100 ns */
+  interval_ms = parameters->dwFrameInterval / 10000;
+  return VIDEO_ERROR_NONE;
+}
+
+//------------- Helper -------------//
+static void fill_color_bar(uint8_t* buffer, unsigned start_position) {
+  /* EBU color bars
+   * See also https://stackoverflow.com/questions/6939422 */
+  static uint8_t const bar_color[8][4] = {
+      /*  Y,   U,   Y,   V */
+      { 235, 128, 235, 128}, /* 100% White */
+      { 219,  16, 219, 138}, /* Yellow */
+      { 188, 154, 188,  16}, /* Cyan */
+      { 173,  42, 173,  26}, /* Green */
+      {  78, 214,  78, 230}, /* Magenta */
+      {  63, 102,  63, 240}, /* Red */
+      {  32, 240,  32, 118}, /* Blue */
+      {  16, 128,  16, 128}, /* Black */
+  };
+  uint8_t* p;
+
+  /* Generate the 1st line */
+  uint8_t* end = &buffer[FRAME_WIDTH * 2];
+  unsigned idx = (FRAME_WIDTH / 2 - 1) - (start_position % (FRAME_WIDTH / 2));
+  p = &buffer[idx * 4];
+  for (unsigned i = 0; i < 8; ++i) {
+    for (int j = 0; j < FRAME_WIDTH / (2 * 8); ++j) {
+      memcpy(p, &bar_color[i], 4);
+      p += 4;
+      if (end <= p) {
+        p = buffer;
+      }
+    }
+  }
+
+  /* Duplicate the 1st line to the others */
+  p = &buffer[FRAME_WIDTH * 2];
+  for (unsigned i = 1; i < FRAME_HEIGHT; ++i) {
+    memcpy(p, buffer, FRAME_WIDTH * 2);
+    p += FRAME_WIDTH * 2;
+  }
 }

--- a/src/Adafruit_TinyUSB.h
+++ b/src/Adafruit_TinyUSB.h
@@ -64,6 +64,10 @@
 #include "arduino/webusb/Adafruit_USBD_WebUSB.h"
 #endif
 
+#if CFG_TUD_VIDEO
+#include "arduino/video/Adafruit_USBD_Video.h"
+#endif
+
 // Initialize device hardware, stack, also Serial as CDC
 // Wrapper for TinyUSBDevice.begin(rhport)
 void TinyUSB_Device_Init(uint8_t rhport);

--- a/src/arduino/ports/nrf/tusb_config_nrf.h
+++ b/src/arduino/ports/nrf/tusb_config_nrf.h
@@ -33,10 +33,7 @@ extern "C" {
 // COMMON CONFIGURATION
 //--------------------------------------------------------------------
 #define CFG_TUSB_MCU OPT_MCU_NRF5X
-
 #define CFG_TUSB_OS OPT_OS_FREERTOS
-#define CFG_TUSB_MEM_SECTION
-#define CFG_TUSB_MEM_ALIGN __attribute__((aligned(4)))
 
 #ifndef CFG_TUSB_DEBUG
 #define CFG_TUSB_DEBUG 0
@@ -44,6 +41,10 @@ extern "C" {
 
 // For selectively disable device log (when > CFG_TUSB_DEBUG)
 // #define CFG_TUD_LOG_LEVEL 3
+// #define CFG_TUH_LOG_LEVEL 3
+
+#define CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_ALIGN __attribute__((aligned(4)))
 
 #ifdef USE_TINYUSB
 // Enable device stack
@@ -70,6 +71,11 @@ extern "C" {
 #define CFG_TUD_HID 2
 #define CFG_TUD_MIDI 1
 #define CFG_TUD_VENDOR 1
+#define CFG_TUD_VIDEO 1           // number of video control interfaces
+#define CFG_TUD_VIDEO_STREAMING 1 // number of video streaming interfaces
+
+// video streaming endpoint buffer size
+#define CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE 256
 
 // CDC FIFO size of TX and RX
 #define CFG_TUD_CDC_RX_BUFSIZE 256

--- a/src/arduino/ports/rp2040/tusb_config_rp2040.h
+++ b/src/arduino/ports/rp2040/tusb_config_rp2040.h
@@ -86,7 +86,11 @@ extern "C" {
 #define CFG_TUD_HID 2
 #define CFG_TUD_MIDI 1
 #define CFG_TUD_VENDOR 1
-// #define CFG_TUD_VIDEO 1
+#define CFG_TUD_VIDEO 1           // number of video control interfaces
+#define CFG_TUD_VIDEO_STREAMING 1 // number of video streaming interfaces
+
+// video streaming endpoint buffer size
+#define CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE 256
 
 // CDC FIFO size of TX and RX
 #define CFG_TUD_CDC_RX_BUFSIZE 256

--- a/src/arduino/ports/samd/tusb_config_samd.h
+++ b/src/arduino/ports/samd/tusb_config_samd.h
@@ -38,7 +38,9 @@ extern "C" {
 #define CFG_TUSB_MCU OPT_MCU_SAMD21
 #endif
 
+#ifndef CFG_TUSB_OS
 #define CFG_TUSB_OS OPT_OS_NONE
+#endif
 
 #ifndef CFG_TUSB_DEBUG
 #define CFG_TUSB_DEBUG 0
@@ -46,6 +48,7 @@ extern "C" {
 
 // For selectively disable device log (when > CFG_TUSB_DEBUG)
 // #define CFG_TUD_LOG_LEVEL 3
+// #define CFG_TUH_LOG_LEVEL 3
 
 #define CFG_TUSB_MEM_SECTION
 #define CFG_TUSB_MEM_ALIGN TU_ATTR_ALIGNED(4)
@@ -69,6 +72,11 @@ extern "C" {
 #define CFG_TUD_HID 2
 #define CFG_TUD_MIDI 1
 #define CFG_TUD_VENDOR 1
+#define CFG_TUD_VIDEO 1           // number of video control interfaces
+#define CFG_TUD_VIDEO_STREAMING 1 // number of video streaming interfaces
+
+// video streaming endpoint buffer size
+#define CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE 256
 
 // CDC FIFO size of TX and RX
 #define CFG_TUD_CDC_RX_BUFSIZE 256

--- a/src/arduino/video/Adafruit_USBD_Video.cpp
+++ b/src/arduino/video/Adafruit_USBD_Video.cpp
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#include "tusb_option.h"
+
+#if CFG_TUD_ENABLED && CFG_TUD_VIDEO && CFG_TUD_VIDEO_STREAMING
+
+#include "Adafruit_USBD_Video.h"
+
+Adafruit_USBD_Video::Adafruit_USBD_Video(uint8_t const *desc_itf,
+                                         size_t desc_len) {
+  _desc_itf = desc_itf;
+  _desc_len = desc_len;
+}
+
+bool Adafruit_USBD_Video::begin() {
+  if (!TinyUSBDevice.addInterface(*this)) {
+    return false;
+  }
+
+  return true;
+}
+
+uint16_t Adafruit_USBD_Video::getInterfaceDescriptor(uint8_t itfnum,
+                                                     uint8_t *buf,
+                                                     uint16_t bufsize) {
+  (void)itfnum;
+
+  if (!buf || bufsize < _desc_len) {
+    return false;
+  }
+
+  memcpy(buf, _desc_itf, _desc_len);
+  return _desc_len;
+}
+
+#endif

--- a/src/arduino/video/Adafruit_USBD_Video.cpp
+++ b/src/arduino/video/Adafruit_USBD_Video.cpp
@@ -34,6 +34,7 @@ Adafruit_USBD_Video::Adafruit_USBD_Video(uint8_t const *desc_itf,
                                          size_t desc_len) {
   _desc_itf = desc_itf;
   _desc_len = desc_len;
+  _vc_id = 0;
 }
 
 bool Adafruit_USBD_Video::begin() {
@@ -56,5 +57,13 @@ uint16_t Adafruit_USBD_Video::getInterfaceDescriptor(uint8_t itfnum,
   memcpy(buf, _desc_itf, _desc_len);
   return _desc_len;
 }
+
+//--------------------------------------------------------------------+
+// API
+//--------------------------------------------------------------------+
+
+// bool Adafruit_USBD_Video::isStreaming(uint8_t stream_idx) {
+//   return tud_video_n_streaming(_vc_id, stream_idx);
+// }
 
 #endif

--- a/src/arduino/video/Adafruit_USBD_Video.h
+++ b/src/arduino/video/Adafruit_USBD_Video.h
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * This file is part of the TinyUSB stack.
+ */
+
+#ifndef ADAFRUIT_USBD_VIDEO_H
+#define ADAFRUIT_USBD_VIDEO_H
+
+#include "arduino/Adafruit_USBD_Device.h"
+
+class Adafruit_USBD_Video : public Adafruit_USBD_Interface {
+public:
+  Adafruit_USBD_Video(uint8_t const *desc_itf, size_t desc_len);
+
+  bool begin();
+
+  // from Adafruit_USBD_Interface
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
+                                          uint16_t bufsize);
+
+private:
+  uint8_t const *_desc_itf;
+  size_t _desc_len;
+};
+
+#endif

--- a/src/arduino/video/Adafruit_USBD_Video.h
+++ b/src/arduino/video/Adafruit_USBD_Video.h
@@ -35,6 +35,9 @@ public:
 
   bool begin();
 
+  //------------- API -------------//
+  //  bool isStreaming(uint8_t stream_idx);
+
   // from Adafruit_USBD_Interface
   virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
                                           uint16_t bufsize);
@@ -42,6 +45,7 @@ public:
 private:
   uint8_t const *_desc_itf;
   size_t _desc_len;
+  uint8_t _vc_id;
 };
 
 #endif


### PR DESCRIPTION
- initial support for UVC
- Add new Adafruit_USBD_Video.cpp/h but it is only used to build configuration descriptor for now. All APIs use native tinyusb tud_video_ call
- Update USBD Device configuration descriptor builder to update/adjust interface number, endpoint address dynamically for video class
- add video_capture.ino example
- enable bulk video streaming for rp2040/samd21/samd51/nrf52840

@ladyada 

![image](https://github.com/adafruit/Adafruit_TinyUSB_Arduino/assets/249515/26cd70f5-d327-42b7-a333-5ebcccead991)
