### PR TITLE
Rework config descriptor builder

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 
@@ -60,7 +60,7 @@ jobs:
 
     steps:
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.cpp
+++ b/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.cpp
@@ -64,15 +64,28 @@ Adafruit_USBD_I2C::Adafruit_USBD_I2C(TwoWire* wire) {
   setStringDescriptor("I2C Interface");
 }
 
-uint16_t Adafruit_USBD_I2C::getInterfaceDescriptor(uint8_t itfnum, uint8_t* buf, uint16_t bufsize) {
-  uint8_t desc[] = { TUD_VENDOR_DESCRIPTOR(itfnum, 0, 0x00, 0x80, 64) };
+uint16_t Adafruit_USBD_I2C::getInterfaceDescriptor(uint8_t itfnum_deprecated, uint8_t* buf, uint16_t bufsize) {
+  uint8_t itfnum = 0;
+  uint8_t ep_in = 0;
+  uint8_t ep_out = 0;
+
+  // null buffer is used to get the length of descriptor only
+  if (buf) {
+    itfnum = TinyUSBDevice.allocInterface(1);
+    ep_in = TinyUSBDevice.allocEndpoint(TUSB_DIR_IN);
+    ep_out = TinyUSBDevice.allocEndpoint(TUSB_DIR_OUT);
+  }
+
+  uint8_t const desc[] = { TUD_VENDOR_DESCRIPTOR(itfnum, _strid, ep_out, ep_in, 64) };
   uint16_t const len = sizeof(desc);
+
   if (buf) {
     if (bufsize < len) {
       return 0;
     }
     memcpy(buf, desc, len);
   }
+
   return len;
 }
 

--- a/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.cpp
+++ b/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.cpp
@@ -64,7 +64,7 @@ Adafruit_USBD_I2C::Adafruit_USBD_I2C(TwoWire* wire) {
   setStringDescriptor("I2C Interface");
 }
 
-uint16_t Adafruit_USBD_I2C::getInterfaceDescriptor(uint8_t* buf, uint16_t bufsize) {
+uint16_t Adafruit_USBD_I2C::getInterfaceDescriptor(uint8_t itfnum_deprecated, uint8_t* buf, uint16_t bufsize) {
   uint8_t itfnum = 0;
   uint8_t ep_in = 0;
   uint8_t ep_out = 0;

--- a/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.cpp
+++ b/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.cpp
@@ -64,7 +64,7 @@ Adafruit_USBD_I2C::Adafruit_USBD_I2C(TwoWire* wire) {
   setStringDescriptor("I2C Interface");
 }
 
-uint16_t Adafruit_USBD_I2C::getInterfaceDescriptor(uint8_t itfnum_deprecated, uint8_t* buf, uint16_t bufsize) {
+uint16_t Adafruit_USBD_I2C::getInterfaceDescriptor(uint8_t* buf, uint16_t bufsize) {
   uint8_t itfnum = 0;
   uint8_t ep_in = 0;
   uint8_t ep_out = 0;

--- a/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.h
+++ b/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.h
@@ -88,10 +88,12 @@
 class Adafruit_USBD_I2C : public Adafruit_USBD_Interface {
 public:
   Adafruit_USBD_I2C(TwoWire* wire);
-  uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t* buf, uint16_t bufsize);
   bool begin(uint8_t* buffer, size_t bufsize);
 
   bool handleControlTransfer(uint8_t rhport, uint8_t stage, tusb_control_request_t const* request);
+
+  // from Adafruit_USBD_Interface
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t* buf, uint16_t bufsize);
 
 private:
   TwoWire* _wire;

--- a/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.h
+++ b/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.h
@@ -93,7 +93,7 @@ public:
   bool handleControlTransfer(uint8_t rhport, uint8_t stage, tusb_control_request_t const* request);
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t* buf, uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t* buf, uint16_t bufsize);
 
 private:
   TwoWire* _wire;

--- a/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.h
+++ b/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.h
@@ -93,7 +93,7 @@ public:
   bool handleControlTransfer(uint8_t rhport, uint8_t stage, tusb_control_request_t const* request);
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t* buf, uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t* buf, uint16_t bufsize);
 
 private:
   TwoWire* _wire;

--- a/src/arduino/Adafruit_TinyUSB_API.h
+++ b/src/arduino/Adafruit_TinyUSB_API.h
@@ -30,7 +30,7 @@
 
 // API Version, need to be updated when there is changes for
 // TinyUSB_API, USBD_CDC, USBD_Device, USBD_Interface,
-#define TINYUSB_API_VERSION 20000
+#define TINYUSB_API_VERSION 20400
 
 //--------------------------------------------------------------------+
 // Core API

--- a/src/arduino/Adafruit_USBD_CDC.cpp
+++ b/src/arduino/Adafruit_USBD_CDC.cpp
@@ -46,8 +46,7 @@ Adafruit_USBD_CDC::Adafruit_USBD_CDC(void) { _instance = INVALID_INSTANCE; }
 
 #if CFG_TUD_ENABLED
 
-uint16_t Adafruit_USBD_CDC::getInterfaceDescriptor(uint8_t itfnum_deprecated,
-                                                   uint8_t *buf,
+uint16_t Adafruit_USBD_CDC::getInterfaceDescriptor(uint8_t *buf,
                                                    uint16_t bufsize) {
   // CDC is mostly always existed for DFU
   uint8_t itfnum = 0;

--- a/src/arduino/Adafruit_USBD_CDC.cpp
+++ b/src/arduino/Adafruit_USBD_CDC.cpp
@@ -49,6 +49,8 @@ Adafruit_USBD_CDC::Adafruit_USBD_CDC(void) { _instance = INVALID_INSTANCE; }
 uint16_t Adafruit_USBD_CDC::getInterfaceDescriptor(uint8_t itfnum_deprecated,
                                                    uint8_t *buf,
                                                    uint16_t bufsize) {
+  (void)itfnum_deprecated;
+
   // CDC is mostly always existed for DFU
   uint8_t itfnum = 0;
   uint8_t ep_notif = 0;
@@ -281,9 +283,10 @@ void tud_cdc_line_state_cb(uint8_t instance, bool dtr, bool rts) {
 // Device stack is not enabled (probably in host mode)
 #warning "TinyUSB Host selected. No output to Serial will occur!"
 
-uint16_t Adafruit_USBD_CDC::getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
+uint16_t Adafruit_USBD_CDC::getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                                   uint8_t *buf,
                                                    uint16_t bufsize) {
-  (void)itfnum;
+  (void)itfnum_deprecated;
   (void)buf;
   (void)bufsize;
 

--- a/src/arduino/Adafruit_USBD_CDC.cpp
+++ b/src/arduino/Adafruit_USBD_CDC.cpp
@@ -46,21 +46,34 @@ Adafruit_USBD_CDC::Adafruit_USBD_CDC(void) { _instance = INVALID_INSTANCE; }
 
 #if CFG_TUD_ENABLED
 
-#define EPOUT 0x00
-#define EPIN 0x80
-
-uint16_t Adafruit_USBD_CDC::getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
+uint16_t Adafruit_USBD_CDC::getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                                   uint8_t *buf,
                                                    uint16_t bufsize) {
   // CDC is mostly always existed for DFU
-  // usb core will automatically update endpoint number
-  uint8_t desc[] = {TUD_CDC_DESCRIPTOR(itfnum, 0, EPIN, 8, EPOUT, EPIN, 64)};
-  uint16_t const len = sizeof(desc);
+  uint8_t itfnum = 0;
+  uint8_t ep_notif = 0;
+  uint8_t ep_in = 0;
+  uint8_t ep_out = 0;
 
-  if (bufsize < len) {
-    return 0;
+  if (buf) {
+    itfnum = TinyUSBDevice.allocInterface(2);
+    ep_notif = TinyUSBDevice.allocEndpoint(TUSB_DIR_IN);
+    ep_in = TinyUSBDevice.allocEndpoint(TUSB_DIR_IN);
+    ep_out = TinyUSBDevice.allocEndpoint(TUSB_DIR_OUT);
   }
 
-  memcpy(buf, desc, len);
+  uint8_t const desc[] = {
+      TUD_CDC_DESCRIPTOR(itfnum, _strid, ep_notif, 8, ep_out, ep_in, 64)};
+  uint16_t const len = sizeof(desc);
+
+  // null buffer is used to get the length of descriptor only
+  if (buf) {
+    if (bufsize < len) {
+      return 0;
+    }
+    memcpy(buf, desc, len);
+  }
+
   return len;
 }
 

--- a/src/arduino/Adafruit_USBD_CDC.cpp
+++ b/src/arduino/Adafruit_USBD_CDC.cpp
@@ -46,7 +46,8 @@ Adafruit_USBD_CDC::Adafruit_USBD_CDC(void) { _instance = INVALID_INSTANCE; }
 
 #if CFG_TUD_ENABLED
 
-uint16_t Adafruit_USBD_CDC::getInterfaceDescriptor(uint8_t *buf,
+uint16_t Adafruit_USBD_CDC::getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                                   uint8_t *buf,
                                                    uint16_t bufsize) {
   // CDC is mostly always existed for DFU
   uint8_t itfnum = 0;

--- a/src/arduino/Adafruit_USBD_CDC.cpp
+++ b/src/arduino/Adafruit_USBD_CDC.cpp
@@ -64,8 +64,14 @@ uint16_t Adafruit_USBD_CDC::getInterfaceDescriptor(uint8_t itfnum_deprecated,
     ep_out = TinyUSBDevice.allocEndpoint(TUSB_DIR_OUT);
   }
 
+#if TINYUSB_API_VERSION < 20400
+  // backward compatible for core that include pre-2.4.0 TinyUSB
+  uint8_t _strid = 0;
+#endif
+
   uint8_t const desc[] = {
       TUD_CDC_DESCRIPTOR(itfnum, _strid, ep_notif, 8, ep_out, ep_in, 64)};
+
   uint16_t const len = sizeof(desc);
 
   // null buffer is used to get the length of descriptor only

--- a/src/arduino/Adafruit_USBD_CDC.h
+++ b/src/arduino/Adafruit_USBD_CDC.h
@@ -45,10 +45,6 @@ public:
 
   static uint8_t getInstanceCount(void) { return _instance_count; }
 
-  // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize);
-
   void setPins(uint8_t pin_rx, uint8_t pin_tx) {
     (void)pin_rx;
     (void)pin_tx;
@@ -82,6 +78,10 @@ public:
   virtual int availableForWrite(void);
   using Print::write; // pull in write(str) from Print
   operator bool();
+
+  // from Adafruit_USBD_Interface
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                          uint8_t *buf, uint16_t bufsize);
 
 private:
   enum { INVALID_INSTANCE = 0xffu };

--- a/src/arduino/Adafruit_USBD_CDC.h
+++ b/src/arduino/Adafruit_USBD_CDC.h
@@ -80,7 +80,8 @@ public:
   operator bool();
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                          uint8_t *buf, uint16_t bufsize);
 
 private:
   enum { INVALID_INSTANCE = 0xffu };

--- a/src/arduino/Adafruit_USBD_CDC.h
+++ b/src/arduino/Adafruit_USBD_CDC.h
@@ -80,8 +80,7 @@ public:
   operator bool();
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum_deprecated,
-                                          uint8_t *buf, uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
 
 private:
   enum { INVALID_INSTANCE = 0xffu };

--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -235,13 +235,14 @@ bool Adafruit_USBD_Device::addInterface(Adafruit_USBD_Interface &itf) {
   uint8_t *desc = _desc_cfg + _desc_cfg_len;
   uint16_t const len = itf.getInterfaceDescriptor(
       _itf_count, desc, _desc_cfg_maxlen - _desc_cfg_len);
-  uint8_t *desc_end = desc + len;
-
-  const char *desc_str = itf.getStringDescriptor();
 
   if (!len) {
     return false;
   }
+
+#if 0
+  uint8_t *desc_end = desc + len;
+  const char *desc_str = itf.getStringDescriptor();
 
   // Parse interface descriptor to update
   // - IAD: interface number
@@ -321,6 +322,7 @@ bool Adafruit_USBD_Device::addInterface(Adafruit_USBD_Interface &itf) {
 
     desc += tu_desc_len(desc);
   }
+#endif
 
   _desc_cfg_len += len;
 

--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -233,8 +233,8 @@ void Adafruit_USBD_Device::clearConfiguration(void) {
 // - Endpoint number is updated to be unique
 bool Adafruit_USBD_Device::addInterface(Adafruit_USBD_Interface &itf) {
   uint8_t *desc = _desc_cfg + _desc_cfg_len;
-  uint16_t const len =
-      itf.getInterfaceDescriptor(desc, _desc_cfg_maxlen - _desc_cfg_len);
+  uint16_t const len = itf.getInterfaceDescriptor(
+      _itf_count, desc, _desc_cfg_maxlen - _desc_cfg_len);
 
   if (!len) {
     return false;

--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -233,8 +233,8 @@ void Adafruit_USBD_Device::clearConfiguration(void) {
 // - Endpoint number is updated to be unique
 bool Adafruit_USBD_Device::addInterface(Adafruit_USBD_Interface &itf) {
   uint8_t *desc = _desc_cfg + _desc_cfg_len;
-  uint16_t const len = itf.getInterfaceDescriptor(
-      _itf_count, desc, _desc_cfg_maxlen - _desc_cfg_len);
+  uint16_t const len =
+      itf.getInterfaceDescriptor(desc, _desc_cfg_maxlen - _desc_cfg_len);
 
   if (!len) {
     return false;

--- a/src/arduino/Adafruit_USBD_Device.h
+++ b/src/arduino/Adafruit_USBD_Device.h
@@ -71,15 +71,25 @@ public:
 
   //------------- Configuration descriptor -------------//
 
-  // Add an new interface
+  // Add a new interface
   bool addInterface(Adafruit_USBD_Interface &itf);
 
   // Clear/Reset configuration descriptor
   void clearConfiguration(void);
 
-  // Provide user buffer for configuration descriptor, needed if total length >
-  // 256
+  // Provide user buffer for configuration descriptor, if total length > 256
   void setConfigurationBuffer(uint8_t *buf, uint32_t buflen);
+
+  // Allocate a new interface number
+  uint8_t allocInterface(uint8_t count = 1) {
+    uint8_t ret = _itf_count;
+    _itf_count += count;
+    return ret;
+  }
+
+  uint8_t allocEndpoint(uint8_t in) {
+    return in ? (0x80 | _epin_count++) : _epout_count++;
+  }
 
   //------------- String descriptor -------------//
   void setLanguageDescriptor(uint16_t language_id);

--- a/src/arduino/Adafruit_USBD_Interface.cpp
+++ b/src/arduino/Adafruit_USBD_Interface.cpp
@@ -22,29 +22,14 @@
  * THE SOFTWARE.
  */
 
-#ifndef ADAFRUIT_USBD_INTERFACE_H_
-#define ADAFRUIT_USBD_INTERFACE_H_
+#include "tusb_option.h"
 
-#include <stddef.h>
-#include <stdint.h>
+#if CFG_TUD_ENABLED
 
-class Adafruit_USBD_Interface {
-protected:
-  uint8_t _strid;
+#include "Adafruit_USBD_Device.h"
 
-public:
-  Adafruit_USBD_Interface(void) { _strid = 0; }
-
-  // Get Interface Descriptor
-  // Fill the descriptor (if buf is not NULL) and return its length
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize) = 0;
-  // Get Interface Descriptor Length
-  uint16_t getInterfaceDescriptorLen() {
-    return getInterfaceDescriptor(0, NULL, 0);
-  }
-
-  void setStringDescriptor(const char *str);
-};
+void Adafruit_USBD_Interface::setStringDescriptor(const char *str) {
+  _strid = TinyUSBDevice.addStringDescriptor(str);
+}
 
 #endif

--- a/src/arduino/Adafruit_USBD_Interface.h
+++ b/src/arduino/Adafruit_USBD_Interface.h
@@ -37,10 +37,11 @@ public:
 
   // Get Interface Descriptor
   // Fill the descriptor (if buf is not NULL) and return its length
-  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize) = 0;
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
+                                          uint16_t bufsize) = 0;
   // Get Interface Descriptor Length
   uint16_t getInterfaceDescriptorLen() {
-    return getInterfaceDescriptor(NULL, 0);
+    return getInterfaceDescriptor(0, NULL, 0);
   }
 
   void setStringDescriptor(const char *str);

--- a/src/arduino/Adafruit_USBD_Interface.h
+++ b/src/arduino/Adafruit_USBD_Interface.h
@@ -37,11 +37,10 @@ public:
 
   // Get Interface Descriptor
   // Fill the descriptor (if buf is not NULL) and return its length
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize) = 0;
+  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize) = 0;
   // Get Interface Descriptor Length
   uint16_t getInterfaceDescriptorLen() {
-    return getInterfaceDescriptor(0, NULL, 0);
+    return getInterfaceDescriptor(NULL, 0);
   }
 
   void setStringDescriptor(const char *str);

--- a/src/arduino/Adafruit_USBD_Interface.h
+++ b/src/arduino/Adafruit_USBD_Interface.h
@@ -37,8 +37,8 @@ public:
 
   // Get Interface Descriptor
   // Fill the descriptor (if buf is not NULL) and return its length
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize) = 0;
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                          uint8_t *buf, uint16_t bufsize) = 0;
   // Get Interface Descriptor Length
   uint16_t getInterfaceDescriptorLen() {
     return getInterfaceDescriptor(0, NULL, 0);

--- a/src/arduino/hid/Adafruit_USBD_HID.cpp
+++ b/src/arduino/hid/Adafruit_USBD_HID.cpp
@@ -161,6 +161,8 @@ uint16_t Adafruit_USBD_HID::makeItfDesc(uint8_t itfnum, uint8_t *buf,
 uint16_t Adafruit_USBD_HID::getInterfaceDescriptor(uint8_t itfnum_deprecated,
                                                    uint8_t *buf,
                                                    uint16_t bufsize) {
+  (void)itfnum_deprecated;
+
   uint8_t itfnum = 0;
   uint8_t ep_in = 0;
   uint8_t ep_out = 0;

--- a/src/arduino/hid/Adafruit_USBD_HID.cpp
+++ b/src/arduino/hid/Adafruit_USBD_HID.cpp
@@ -158,7 +158,8 @@ uint16_t Adafruit_USBD_HID::makeItfDesc(uint8_t itfnum, uint8_t *buf,
   return len;
 }
 
-uint16_t Adafruit_USBD_HID::getInterfaceDescriptor(uint8_t *buf,
+uint16_t Adafruit_USBD_HID::getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                                   uint8_t *buf,
                                                    uint16_t bufsize) {
   uint8_t itfnum = 0;
   uint8_t ep_in = 0;

--- a/src/arduino/hid/Adafruit_USBD_HID.cpp
+++ b/src/arduino/hid/Adafruit_USBD_HID.cpp
@@ -28,9 +28,6 @@
 
 #include "Adafruit_USBD_HID.h"
 
-#define EPOUT 0x00
-#define EPIN 0x80
-
 uint8_t const _ascii2keycode[128][2] = {HID_ASCII_TO_KEYCODE};
 static Adafruit_USBD_HID *_hid_instances[CFG_TUD_HID] = {0};
 
@@ -94,7 +91,7 @@ Adafruit_USBD_HID::Adafruit_USBD_HID(uint8_t const *desc_report, uint16_t len,
   _instance = _instance_count++;
   _hid_instances[_instance] = this;
 
-  uint16_t const desc_len = getInterfaceDescriptor(0, NULL, 0);
+  uint16_t const desc_len = getInterfaceDescriptorLen();
   tinyusb_enable_interface(USB_INTERFACE_HID, desc_len, hid_load_descriptor);
 #endif
 }
@@ -132,11 +129,11 @@ uint16_t Adafruit_USBD_HID::makeItfDesc(uint8_t itfnum, uint8_t *buf,
     return 0;
   }
 
-  uint8_t const desc_inout[] = {
-      TUD_HID_INOUT_DESCRIPTOR(itfnum, 0, _protocol, _desc_report_len, ep_in,
-                               ep_out, CFG_TUD_HID_EP_BUFSIZE, _interval_ms)};
+  uint8_t const desc_inout[] = {TUD_HID_INOUT_DESCRIPTOR(
+      itfnum, _strid, _protocol, _desc_report_len, ep_in, ep_out,
+      CFG_TUD_HID_EP_BUFSIZE, _interval_ms)};
   uint8_t const desc_in_only[] = {
-      TUD_HID_DESCRIPTOR(itfnum, 0, _protocol, _desc_report_len, ep_in,
+      TUD_HID_DESCRIPTOR(itfnum, _strid, _protocol, _desc_report_len, ep_in,
                          CFG_TUD_HID_EP_BUFSIZE, _interval_ms)};
 
   uint8_t const *desc;
@@ -155,17 +152,30 @@ uint16_t Adafruit_USBD_HID::makeItfDesc(uint8_t itfnum, uint8_t *buf,
     if (bufsize < len) {
       return 0;
     }
-
     memcpy(buf, desc, len);
   }
 
   return len;
 }
 
-uint16_t Adafruit_USBD_HID::getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
+uint16_t Adafruit_USBD_HID::getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                                   uint8_t *buf,
                                                    uint16_t bufsize) {
-  // usb core will automatically update endpoint number
-  return makeItfDesc(itfnum, buf, bufsize, EPIN, EPOUT);
+  uint8_t itfnum = 0;
+  uint8_t ep_in = 0;
+  uint8_t ep_out = 0;
+
+  // null buffer is used to get the length of descriptor only
+  if (buf) {
+    itfnum = TinyUSBDevice.allocInterface(1);
+    ep_in = TinyUSBDevice.allocEndpoint(TUSB_DIR_IN);
+
+    if (_out_endpoint) {
+      TinyUSBDevice.allocEndpoint(TUSB_DIR_OUT);
+    }
+  }
+
+  return makeItfDesc(itfnum, buf, bufsize, ep_in, ep_out);
 }
 
 bool Adafruit_USBD_HID::begin(void) {

--- a/src/arduino/hid/Adafruit_USBD_HID.cpp
+++ b/src/arduino/hid/Adafruit_USBD_HID.cpp
@@ -158,8 +158,7 @@ uint16_t Adafruit_USBD_HID::makeItfDesc(uint8_t itfnum, uint8_t *buf,
   return len;
 }
 
-uint16_t Adafruit_USBD_HID::getInterfaceDescriptor(uint8_t itfnum_deprecated,
-                                                   uint8_t *buf,
+uint16_t Adafruit_USBD_HID::getInterfaceDescriptor(uint8_t *buf,
                                                    uint16_t bufsize) {
   uint8_t itfnum = 0;
   uint8_t ep_in = 0;

--- a/src/arduino/hid/Adafruit_USBD_HID.h
+++ b/src/arduino/hid/Adafruit_USBD_HID.h
@@ -80,8 +80,8 @@ public:
   bool mouseButtonRelease(uint8_t report_id);
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                          uint8_t *buf, uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,

--- a/src/arduino/hid/Adafruit_USBD_HID.h
+++ b/src/arduino/hid/Adafruit_USBD_HID.h
@@ -80,8 +80,7 @@ public:
   bool mouseButtonRelease(uint8_t report_id);
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,

--- a/src/arduino/hid/Adafruit_USBD_HID.h
+++ b/src/arduino/hid/Adafruit_USBD_HID.h
@@ -80,7 +80,8 @@ public:
   bool mouseButtonRelease(uint8_t report_id);
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
+                                          uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,

--- a/src/arduino/midi/Adafruit_USBD_MIDI.cpp
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.cpp
@@ -31,8 +31,6 @@
 //--------------------------------------------------------------------+
 // MACRO TYPEDEF CONSTANT ENUM DECLARATION
 //--------------------------------------------------------------------+
-#define EPOUT 0x00
-#define EPIN 0x80
 #define EPSIZE 64
 
 // TODO multiple instances
@@ -47,8 +45,7 @@ static uint16_t midi_load_descriptor(uint8_t *dst, uint8_t *itf) {
   TU_VERIFY(ep_in && ep_out);
   ep_in |= 0x80;
 
-  uint16_t desc_len = _midi_dev->getInterfaceDescriptor(0, NULL, 0);
-
+  uint16_t desc_len = _midi_dev->getInterfaceDescriptorLen();
   desc_len = _midi_dev->makeItfDesc(*itf, dst, desc_len, ep_in, ep_out);
 
   *itf += 2;
@@ -63,7 +60,7 @@ Adafruit_USBD_MIDI::Adafruit_USBD_MIDI(uint8_t n_cables) {
 #ifdef ARDUINO_ARCH_ESP32
   // ESP32 requires setup configuration descriptor within constructor
   _midi_dev = this;
-  uint16_t const desc_len = getInterfaceDescriptor(0, NULL, 0);
+  uint16_t const desc_len = getInterfaceDescriptorLen();
   tinyusb_enable_interface(USB_INTERFACE_MIDI, desc_len, midi_load_descriptor);
 #endif
 }
@@ -110,7 +107,7 @@ uint16_t Adafruit_USBD_MIDI::makeItfDesc(uint8_t itfnum, uint8_t *buf,
 
   // Header
   {
-    uint8_t desc[] = {TUD_MIDI_DESC_HEAD(itfnum, 0, _n_cables)};
+    uint8_t desc[] = {TUD_MIDI_DESC_HEAD(itfnum, _strid, _n_cables)};
     memcpy(buf + len, desc, sizeof(desc));
     len += sizeof(desc);
   }
@@ -156,10 +153,21 @@ uint16_t Adafruit_USBD_MIDI::makeItfDesc(uint8_t itfnum, uint8_t *buf,
   return desc_len;
 }
 
-uint16_t Adafruit_USBD_MIDI::getInterfaceDescriptor(uint8_t itfnum,
+uint16_t Adafruit_USBD_MIDI::getInterfaceDescriptor(uint8_t itfnum_deprecated,
                                                     uint8_t *buf,
                                                     uint16_t bufsize) {
-  return makeItfDesc(itfnum, buf, bufsize, EPIN, EPOUT);
+  uint8_t itfnum = 0;
+  uint8_t ep_in = 0;
+  uint8_t ep_out = 0;
+
+  // null buffer is used to get the length of descriptor only
+  if (buf) {
+    itfnum = TinyUSBDevice.allocInterface(2);
+    ep_in = TinyUSBDevice.allocEndpoint(TUSB_DIR_IN);
+    ep_out = TinyUSBDevice.allocEndpoint(TUSB_DIR_OUT);
+  }
+
+  return makeItfDesc(itfnum, buf, bufsize, ep_in, ep_out);
 }
 
 int Adafruit_USBD_MIDI::read(void) {

--- a/src/arduino/midi/Adafruit_USBD_MIDI.cpp
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.cpp
@@ -153,8 +153,7 @@ uint16_t Adafruit_USBD_MIDI::makeItfDesc(uint8_t itfnum, uint8_t *buf,
   return desc_len;
 }
 
-uint16_t Adafruit_USBD_MIDI::getInterfaceDescriptor(uint8_t itfnum_deprecated,
-                                                    uint8_t *buf,
+uint16_t Adafruit_USBD_MIDI::getInterfaceDescriptor(uint8_t *buf,
                                                     uint16_t bufsize) {
   uint8_t itfnum = 0;
   uint8_t ep_in = 0;

--- a/src/arduino/midi/Adafruit_USBD_MIDI.cpp
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.cpp
@@ -153,7 +153,8 @@ uint16_t Adafruit_USBD_MIDI::makeItfDesc(uint8_t itfnum, uint8_t *buf,
   return desc_len;
 }
 
-uint16_t Adafruit_USBD_MIDI::getInterfaceDescriptor(uint8_t *buf,
+uint16_t Adafruit_USBD_MIDI::getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                                    uint8_t *buf,
                                                     uint16_t bufsize) {
   uint8_t itfnum = 0;
   uint8_t ep_in = 0;

--- a/src/arduino/midi/Adafruit_USBD_MIDI.cpp
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.cpp
@@ -156,6 +156,8 @@ uint16_t Adafruit_USBD_MIDI::makeItfDesc(uint8_t itfnum, uint8_t *buf,
 uint16_t Adafruit_USBD_MIDI::getInterfaceDescriptor(uint8_t itfnum_deprecated,
                                                     uint8_t *buf,
                                                     uint16_t bufsize) {
+  (void)itfnum_deprecated;
+
   uint8_t itfnum = 0;
   uint8_t ep_in = 0;
   uint8_t ep_out = 0;

--- a/src/arduino/midi/Adafruit_USBD_MIDI.h
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.h
@@ -60,8 +60,8 @@ public:
   bool readPacket(uint8_t packet[4]);
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                          uint8_t *buf, uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,

--- a/src/arduino/midi/Adafruit_USBD_MIDI.h
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.h
@@ -60,7 +60,8 @@ public:
   bool readPacket(uint8_t packet[4]);
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
+                                          uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,

--- a/src/arduino/midi/Adafruit_USBD_MIDI.h
+++ b/src/arduino/midi/Adafruit_USBD_MIDI.h
@@ -60,8 +60,7 @@ public:
   bool readPacket(uint8_t packet[4]);
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,

--- a/src/arduino/msc/Adafruit_USBD_MSC.cpp
+++ b/src/arduino/msc/Adafruit_USBD_MSC.cpp
@@ -76,8 +76,7 @@ uint16_t Adafruit_USBD_MSC::makeItfDesc(uint8_t itfnum, uint8_t *buf,
   return len;
 }
 
-uint16_t Adafruit_USBD_MSC::getInterfaceDescriptor(uint8_t itfnum_deprecated,
-                                                   uint8_t *buf,
+uint16_t Adafruit_USBD_MSC::getInterfaceDescriptor(uint8_t *buf,
                                                    uint16_t bufsize) {
   // null buffer is used to get the length of descriptor only
   if (!buf) {
@@ -85,7 +84,6 @@ uint16_t Adafruit_USBD_MSC::getInterfaceDescriptor(uint8_t itfnum_deprecated,
   }
 
   uint8_t const itfnum = TinyUSBDevice.allocInterface(1);
-  ;
   uint8_t const ep_in = TinyUSBDevice.allocEndpoint(TUSB_DIR_IN);
   uint8_t const ep_out = TinyUSBDevice.allocEndpoint(TUSB_DIR_OUT);
 

--- a/src/arduino/msc/Adafruit_USBD_MSC.cpp
+++ b/src/arduino/msc/Adafruit_USBD_MSC.cpp
@@ -28,8 +28,6 @@
 
 #include "Adafruit_USBD_MSC.h"
 
-#define EPOUT 0x00
-#define EPIN 0x80
 #define EPSIZE 64 // TODO must be 512 for highspeed device
 
 static Adafruit_USBD_MSC *_msc_dev = NULL;
@@ -44,13 +42,10 @@ static uint16_t msc_load_descriptor(uint8_t *dst, uint8_t *itf) {
   TU_VERIFY(ep_in && ep_out);
   ep_in |= 0x80;
 
-  uint8_t const descriptor[TUD_MSC_DESC_LEN] = {
-      // Interface number, string index, EP Out & EP In address, EP size
-      TUD_MSC_DESCRIPTOR(*itf, str_index, ep_out, ep_in, EPSIZE)};
-
+  uint16_t const desc_len =
+      _msc_dev->makeItfDesc(*itf, dst, TUD_MSC_DESC_LEN, ep_in, ep_out);
   *itf += 1;
-  memcpy(dst, descriptor, TUD_MSC_DESC_LEN);
-  return TUD_MSC_DESC_LEN;
+  return desc_len;
 }
 #endif
 
@@ -60,23 +55,41 @@ Adafruit_USBD_MSC::Adafruit_USBD_MSC(void) {
 
 #ifdef ARDUINO_ARCH_ESP32
   // ESP32 requires setup configuration descriptor on declaration
+  _msc_dev = this;
   tinyusb_enable_interface(USB_INTERFACE_MSC, TUD_MSC_DESC_LEN,
                            msc_load_descriptor);
 #endif
 }
 
-uint16_t Adafruit_USBD_MSC::getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                                   uint16_t bufsize) {
-  // usb core will automatically update endpoint number
-  uint8_t const desc[] = {TUD_MSC_DESCRIPTOR(itfnum, 0, EPOUT, EPIN, EPSIZE)};
+uint16_t Adafruit_USBD_MSC::makeItfDesc(uint8_t itfnum, uint8_t *buf,
+                                        uint16_t bufsize, uint8_t ep_in,
+                                        uint8_t ep_out) {
+  uint8_t const desc[] = {
+      TUD_MSC_DESCRIPTOR(itfnum, _strid, ep_out, ep_in, EPSIZE)};
   uint16_t const len = sizeof(desc);
 
   if (bufsize < len) {
     return 0;
   }
-
   memcpy(buf, desc, len);
+
   return len;
+}
+
+uint16_t Adafruit_USBD_MSC::getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                                   uint8_t *buf,
+                                                   uint16_t bufsize) {
+  // null buffer is used to get the length of descriptor only
+  if (!buf) {
+    return TUD_MSC_DESC_LEN;
+  }
+
+  uint8_t const itfnum = TinyUSBDevice.allocInterface(1);
+  ;
+  uint8_t const ep_in = TinyUSBDevice.allocEndpoint(TUSB_DIR_IN);
+  uint8_t const ep_out = TinyUSBDevice.allocEndpoint(TUSB_DIR_OUT);
+
+  return makeItfDesc(itfnum, buf, bufsize, ep_in, ep_out);
 }
 
 void Adafruit_USBD_MSC::setMaxLun(uint8_t maxlun) { _maxlun = maxlun; }

--- a/src/arduino/msc/Adafruit_USBD_MSC.cpp
+++ b/src/arduino/msc/Adafruit_USBD_MSC.cpp
@@ -76,7 +76,8 @@ uint16_t Adafruit_USBD_MSC::makeItfDesc(uint8_t itfnum, uint8_t *buf,
   return len;
 }
 
-uint16_t Adafruit_USBD_MSC::getInterfaceDescriptor(uint8_t *buf,
+uint16_t Adafruit_USBD_MSC::getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                                   uint8_t *buf,
                                                    uint16_t bufsize) {
   // null buffer is used to get the length of descriptor only
   if (!buf) {
@@ -84,6 +85,7 @@ uint16_t Adafruit_USBD_MSC::getInterfaceDescriptor(uint8_t *buf,
   }
 
   uint8_t const itfnum = TinyUSBDevice.allocInterface(1);
+  ;
   uint8_t const ep_in = TinyUSBDevice.allocEndpoint(TUSB_DIR_IN);
   uint8_t const ep_out = TinyUSBDevice.allocEndpoint(TUSB_DIR_OUT);
 

--- a/src/arduino/msc/Adafruit_USBD_MSC.cpp
+++ b/src/arduino/msc/Adafruit_USBD_MSC.cpp
@@ -79,13 +79,14 @@ uint16_t Adafruit_USBD_MSC::makeItfDesc(uint8_t itfnum, uint8_t *buf,
 uint16_t Adafruit_USBD_MSC::getInterfaceDescriptor(uint8_t itfnum_deprecated,
                                                    uint8_t *buf,
                                                    uint16_t bufsize) {
+  (void)itfnum_deprecated;
+
   // null buffer is used to get the length of descriptor only
   if (!buf) {
     return TUD_MSC_DESC_LEN;
   }
 
   uint8_t const itfnum = TinyUSBDevice.allocInterface(1);
-  ;
   uint8_t const ep_in = TinyUSBDevice.allocEndpoint(TUSB_DIR_IN);
   uint8_t const ep_out = TinyUSBDevice.allocEndpoint(TUSB_DIR_OUT);
 

--- a/src/arduino/msc/Adafruit_USBD_MSC.cpp
+++ b/src/arduino/msc/Adafruit_USBD_MSC.cpp
@@ -35,7 +35,7 @@ static Adafruit_USBD_MSC *_msc_dev = NULL;
 #ifdef ARDUINO_ARCH_ESP32
 static uint16_t msc_load_descriptor(uint8_t *dst, uint8_t *itf) {
   // uint8_t str_index = tinyusb_add_string_descriptor("TinyUSB MSC");
-  uint8_t str_index = 0;
+  // uint8_t str_index = 0;
 
   uint8_t ep_in = tinyusb_get_free_in_endpoint();
   uint8_t ep_out = tinyusb_get_free_out_endpoint();

--- a/src/arduino/msc/Adafruit_USBD_MSC.h
+++ b/src/arduino/msc/Adafruit_USBD_MSC.h
@@ -86,6 +86,10 @@ public:
   virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
                                           uint16_t bufsize);
 
+  // internal use only
+  uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,
+                       uint8_t ep_in, uint8_t ep_out);
+
 private:
   enum { MAX_LUN = 2 }; // TODO make it configurable
   struct {

--- a/src/arduino/msc/Adafruit_USBD_MSC.h
+++ b/src/arduino/msc/Adafruit_USBD_MSC.h
@@ -83,8 +83,7 @@ public:
   }
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,

--- a/src/arduino/msc/Adafruit_USBD_MSC.h
+++ b/src/arduino/msc/Adafruit_USBD_MSC.h
@@ -83,8 +83,8 @@ public:
   }
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                          uint8_t *buf, uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,

--- a/src/arduino/msc/Adafruit_USBD_MSC.h
+++ b/src/arduino/msc/Adafruit_USBD_MSC.h
@@ -83,7 +83,8 @@ public:
   }
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
+                                          uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,

--- a/src/arduino/video/Adafruit_USBD_Video.h
+++ b/src/arduino/video/Adafruit_USBD_Video.h
@@ -39,7 +39,8 @@ public:
   //  bool isStreaming(uint8_t stream_idx);
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
+                                          uint16_t bufsize);
 
 private:
   uint8_t const *_desc_itf;

--- a/src/arduino/video/Adafruit_USBD_Video.h
+++ b/src/arduino/video/Adafruit_USBD_Video.h
@@ -39,8 +39,7 @@ public:
   //  bool isStreaming(uint8_t stream_idx);
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
 
 private:
   uint8_t const *_desc_itf;

--- a/src/arduino/video/Adafruit_USBD_Video.h
+++ b/src/arduino/video/Adafruit_USBD_Video.h
@@ -39,8 +39,8 @@ public:
   //  bool isStreaming(uint8_t stream_idx);
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                          uint8_t *buf, uint16_t bufsize);
 
 private:
   uint8_t const *_desc_itf;

--- a/src/arduino/webusb/Adafruit_USBD_WebUSB.cpp
+++ b/src/arduino/webusb/Adafruit_USBD_WebUSB.cpp
@@ -36,8 +36,6 @@
 //--------------------------------------------------------------------+
 // MACRO TYPEDEF CONSTANT ENUM DECLARATION
 //--------------------------------------------------------------------+
-#define EPOUT 0x00
-#define EPIN 0x80
 #define EPSIZE 64
 
 enum { VENDOR_REQUEST_WEBUSB = 1, VENDOR_REQUEST_MICROSOFT = 2 };
@@ -134,8 +132,7 @@ static uint16_t webusb_load_descriptor(uint8_t *dst, uint8_t *itf) {
   TU_VERIFY(ep_in && ep_out);
   ep_in |= 0x80;
 
-  uint16_t desc_len = _webusb_dev->getInterfaceDescriptor(0, NULL, 0);
-
+  uint16_t desc_len = _webusb_dev->getInterfaceDescriptorLen();
   desc_len = _webusb_dev->makeItfDesc(*itf, dst, desc_len, ep_in, ep_out);
 
   *itf += 1;
@@ -155,7 +152,7 @@ Adafruit_USBD_WebUSB::Adafruit_USBD_WebUSB(const void *url) {
   USB.usbVersion(0x0210);
 
   _webusb_dev = this;
-  uint16_t const desc_len = getInterfaceDescriptor(0, NULL, 0);
+  uint16_t const desc_len = getInterfaceDescriptorLen();
   tinyusb_enable_interface(USB_INTERFACE_VENDOR, desc_len,
                            webusb_load_descriptor);
 #endif
@@ -185,7 +182,8 @@ void Adafruit_USBD_WebUSB::setLineStateCallback(linestate_callback_t fp) {
 uint16_t Adafruit_USBD_WebUSB::makeItfDesc(uint8_t itfnum, uint8_t *buf,
                                            uint16_t bufsize, uint8_t ep_in,
                                            uint8_t ep_out) {
-  uint8_t desc[] = {TUD_VENDOR_DESCRIPTOR(itfnum, 0, ep_out, ep_in, EPSIZE)};
+  uint8_t desc[] = {
+      TUD_VENDOR_DESCRIPTOR(itfnum, _strid, ep_out, ep_in, EPSIZE)};
   uint16_t const len = sizeof(desc);
 
   // null buffer for length only
@@ -204,11 +202,19 @@ uint16_t Adafruit_USBD_WebUSB::makeItfDesc(uint8_t itfnum, uint8_t *buf,
   return len;
 }
 
-uint16_t Adafruit_USBD_WebUSB::getInterfaceDescriptor(uint8_t itfnum,
+uint16_t Adafruit_USBD_WebUSB::getInterfaceDescriptor(uint8_t itfnum_deprecated,
                                                       uint8_t *buf,
                                                       uint16_t bufsize) {
-  // usb core will automatically update endpoint number
-  return makeItfDesc(itfnum, buf, bufsize, EPIN, EPOUT);
+  if (!buf) {
+    return TUD_VENDOR_DESC_LEN;
+  }
+
+  uint8_t const itfnum = TinyUSBDevice.allocInterface(1);
+  ;
+  uint8_t const ep_in = TinyUSBDevice.allocEndpoint(TUSB_DIR_IN);
+  uint8_t const ep_out = TinyUSBDevice.allocEndpoint(TUSB_DIR_OUT);
+
+  return makeItfDesc(itfnum, buf, bufsize, ep_in, ep_out);
 }
 
 bool Adafruit_USBD_WebUSB::connected(void) {

--- a/src/arduino/webusb/Adafruit_USBD_WebUSB.cpp
+++ b/src/arduino/webusb/Adafruit_USBD_WebUSB.cpp
@@ -202,7 +202,8 @@ uint16_t Adafruit_USBD_WebUSB::makeItfDesc(uint8_t itfnum, uint8_t *buf,
   return len;
 }
 
-uint16_t Adafruit_USBD_WebUSB::getInterfaceDescriptor(uint8_t *buf,
+uint16_t Adafruit_USBD_WebUSB::getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                                      uint8_t *buf,
                                                       uint16_t bufsize) {
   if (!buf) {
     return TUD_VENDOR_DESC_LEN;

--- a/src/arduino/webusb/Adafruit_USBD_WebUSB.cpp
+++ b/src/arduino/webusb/Adafruit_USBD_WebUSB.cpp
@@ -205,6 +205,8 @@ uint16_t Adafruit_USBD_WebUSB::makeItfDesc(uint8_t itfnum, uint8_t *buf,
 uint16_t Adafruit_USBD_WebUSB::getInterfaceDescriptor(uint8_t itfnum_deprecated,
                                                       uint8_t *buf,
                                                       uint16_t bufsize) {
+  (void)itfnum_deprecated;
+
   if (!buf) {
     return TUD_VENDOR_DESC_LEN;
   }

--- a/src/arduino/webusb/Adafruit_USBD_WebUSB.cpp
+++ b/src/arduino/webusb/Adafruit_USBD_WebUSB.cpp
@@ -202,8 +202,7 @@ uint16_t Adafruit_USBD_WebUSB::makeItfDesc(uint8_t itfnum, uint8_t *buf,
   return len;
 }
 
-uint16_t Adafruit_USBD_WebUSB::getInterfaceDescriptor(uint8_t itfnum_deprecated,
-                                                      uint8_t *buf,
+uint16_t Adafruit_USBD_WebUSB::getInterfaceDescriptor(uint8_t *buf,
                                                       uint16_t bufsize) {
   if (!buf) {
     return TUD_VENDOR_DESC_LEN;

--- a/src/arduino/webusb/Adafruit_USBD_WebUSB.h
+++ b/src/arduino/webusb/Adafruit_USBD_WebUSB.h
@@ -65,8 +65,8 @@ public:
   operator bool();
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum_deprecated,
+                                          uint8_t *buf, uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,

--- a/src/arduino/webusb/Adafruit_USBD_WebUSB.h
+++ b/src/arduino/webusb/Adafruit_USBD_WebUSB.h
@@ -65,7 +65,8 @@ public:
   operator bool();
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
+                                          uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,

--- a/src/arduino/webusb/Adafruit_USBD_WebUSB.h
+++ b/src/arduino/webusb/Adafruit_USBD_WebUSB.h
@@ -65,8 +65,7 @@ public:
   operator bool();
 
   // from Adafruit_USBD_Interface
-  virtual uint16_t getInterfaceDescriptor(uint8_t itfnum, uint8_t *buf,
-                                          uint16_t bufsize);
+  virtual uint16_t getInterfaceDescriptor(uint8_t *buf, uint16_t bufsize);
 
   // internal use only
   uint16_t makeItfDesc(uint8_t itfnum, uint8_t *buf, uint16_t bufsize,


### PR DESCRIPTION
rework configuration builder, remove auto interface and endpoint numbering. Leave that to each interface instead. Add
- Adafruit_USBD_Device: allocInterface(), allocEndpoint()
- change Adafruit_USBD_Interface::setStringDescriptor() to use Adafruit_USBD_Device::addStringDescriptor() and store _strid.
- Update all class driver interface to use new configuration API(): CDC, MSC, HID, MIDI, Vendor, Webusb