### PR TITLE
fix spelling of CFG_TUD_ENDPOINT0_SIZE in ports

### DIFF
--- a/src/arduino/ports/nrf/tusb_config_nrf.h
+++ b/src/arduino/ports/nrf/tusb_config_nrf.h
@@ -63,7 +63,8 @@ extern "C" {
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
 
-#define CFG_TUD_ENDOINT0_SIZE 64
+// This is the default
+// #define CFG_TUD_ENDPOINT0_SIZE 64
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC 1

--- a/src/arduino/ports/rp2040/tusb_config_rp2040.h
+++ b/src/arduino/ports/rp2040/tusb_config_rp2040.h
@@ -79,7 +79,8 @@ extern "C" {
 // Device Configuration
 //--------------------------------------------------------------------
 
-#define CFG_TUD_ENDOINT0_SIZE 64
+// This is the default
+// #define CFG_TUD_ENDPOINT0_SIZE 64
 
 #define CFG_TUD_CDC 1
 #define CFG_TUD_MSC 1

--- a/src/arduino/ports/samd/tusb_config_samd.h
+++ b/src/arduino/ports/samd/tusb_config_samd.h
@@ -64,7 +64,8 @@ extern "C" {
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
 
-#define CFG_TUD_ENDOINT0_SIZE 64
+// This is the default
+// #define CFG_TUD_ENDPOINT0_SIZE 64
 
 //------------- CLASS -------------//
 #define CFG_TUD_CDC 1


### PR DESCRIPTION
Also comment it out, because each setting was already the default, and it seems unlikely that someone will want to override it.

Fixes #374.
