### PR TITLE
allow override of TUD interface counts

### DIFF
--- a/src/arduino/ports/nrf/tusb_config_nrf.h
+++ b/src/arduino/ports/nrf/tusb_config_nrf.h
@@ -66,13 +66,27 @@ extern "C" {
 #define CFG_TUD_ENDOINT0_SIZE 64
 
 //------------- CLASS -------------//
+#ifndef CFG_TUD_CDC
 #define CFG_TUD_CDC 1
+#endif
+#ifndef CFG_TUD_MSC
 #define CFG_TUD_MSC 1
+#endif
+#ifndef CFG_TUD_HID
 #define CFG_TUD_HID 2
+#endif
+#ifndef CFG_TUD_MIDI
 #define CFG_TUD_MIDI 1
+#endif
+#ifndef CFG_TUD_VENDOR
 #define CFG_TUD_VENDOR 1
-#define CFG_TUD_VIDEO 1           // number of video control interfaces
+#endif
+#ifndef CFG_TUD_VIDEO
+#define CFG_TUD_VIDEO 1 // number of video control interfaces
+#endif
+#ifndef CFG_TUD_VIDEO_STREAMING
 #define CFG_TUD_VIDEO_STREAMING 1 // number of video streaming interfaces
+#endif
 
 // video streaming endpoint buffer size
 #define CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE 256

--- a/src/arduino/ports/rp2040/tusb_config_rp2040.h
+++ b/src/arduino/ports/rp2040/tusb_config_rp2040.h
@@ -81,13 +81,27 @@ extern "C" {
 
 #define CFG_TUD_ENDOINT0_SIZE 64
 
+#ifndef CFG_TUD_CDC
 #define CFG_TUD_CDC 1
+#endif
+#ifndef CFG_TUD_MSC
 #define CFG_TUD_MSC 1
+#endif
+#ifndef CFG_TUD_HID
 #define CFG_TUD_HID 2
+#endif
+#ifndef CFG_TUD_MIDI
 #define CFG_TUD_MIDI 1
+#endif
+#ifndef CFG_TUD_VENDOR
 #define CFG_TUD_VENDOR 1
-#define CFG_TUD_VIDEO 1           // number of video control interfaces
+#endif
+#ifndef CFG_TUD_VIDEO
+#define CFG_TUD_VIDEO 1 // number of video control interfaces
+#endif
+#ifndef CFG_TUD_VIDEO_STREAMING
 #define CFG_TUD_VIDEO_STREAMING 1 // number of video streaming interfaces
+#endif
 
 // video streaming endpoint buffer size
 #define CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE 256

--- a/src/arduino/ports/samd/tusb_config_samd.h
+++ b/src/arduino/ports/samd/tusb_config_samd.h
@@ -67,13 +67,27 @@ extern "C" {
 #define CFG_TUD_ENDOINT0_SIZE 64
 
 //------------- CLASS -------------//
+#ifndef CFG_TUD_CDC
 #define CFG_TUD_CDC 1
+#endif
+#ifndef CFG_TUD_MSC
 #define CFG_TUD_MSC 1
+#endif
+#ifndef CFG_TUD_HID
 #define CFG_TUD_HID 2
+#endif
+#ifndef CFG_TUD_MIDI
 #define CFG_TUD_MIDI 1
+#endif
+#ifndef CFG_TUD_VENDOR
 #define CFG_TUD_VENDOR 1
-#define CFG_TUD_VIDEO 1           // number of video control interfaces
+#endif
+#ifndef CFG_TUD_VIDEO
+#define CFG_TUD_VIDEO 1 // number of video control interfaces
+#endif
+#ifndef CFG_TUD_VIDEO_STREAMING
 #define CFG_TUD_VIDEO_STREAMING 1 // number of video streaming interfaces
+#endif
 
 // video streaming endpoint buffer size
 #define CFG_TUD_VIDEO_STREAMING_EP_BUFSIZE 256


### PR DESCRIPTION
This allows a board definition to override interface counts on the compiler command line, instead of replacing the entire tusb_config.h file.