### PR TITLE
add Adafruit_USBD_HID::getProtocol

### DIFF
--- a/src/arduino/hid/Adafruit_USBD_HID.cpp
+++ b/src/arduino/hid/Adafruit_USBD_HID.cpp
@@ -217,6 +217,10 @@ bool Adafruit_USBD_HID::sendReport32(uint8_t report_id, uint32_t num) {
   return tud_hid_n_report(_instance, report_id, &num, sizeof(num));
 }
 
+uint8_t Adafruit_USBD_HID::getProtocol() {
+  return tud_hid_n_get_protocol(_instance);
+}
+
 //------------- TinyUSB callbacks -------------//
 extern "C" {
 

--- a/src/arduino/hid/Adafruit_USBD_HID.h
+++ b/src/arduino/hid/Adafruit_USBD_HID.h
@@ -61,6 +61,8 @@ public:
   bool ready(void);
   bool sendReport(uint8_t report_id, void const *report, uint8_t len);
 
+  uint8_t getProtocol();
+
   // Report helpers
   bool sendReport8(uint8_t report_id, uint8_t num);
   bool sendReport16(uint8_t report_id, uint16_t num);


### PR DESCRIPTION
Add a getProtocol method, allowing an application to query whether the HID interface is currently set to Boot or Report Protocol.

Fixes #381.