### PR TITLE
Fix GCC 12.3 warning in USB Video core

### DIFF
--- a/src/arduino/video/Adafruit_USBD_Video.cpp
+++ b/src/arduino/video/Adafruit_USBD_Video.cpp
@@ -230,7 +230,7 @@ uint16_t Adafruit_USBD_Video::getInterfaceDescriptor(uint8_t itfnum_deprecated,
              .bDescriptorType = TUSB_DESC_ENDPOINT,
 
              .bEndpointAddress = ep_in,
-             .bmAttributes = {.xfer = TUSB_XFER_BULK, .sync = 0},
+             .bmAttributes = {.xfer = TUSB_XFER_BULK, .sync = 0, .usage = 0},
              .wMaxPacketSize = 64,
              .bInterval = 1}};
 


### PR DESCRIPTION
GCC 12 complains when a structure member is not initialized, so set a sane default value.

Fixes #385