### PR TITLE
Remove GCC 12 warning in Vendor example

### DIFF
--- a/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.cpp
+++ b/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.cpp
@@ -68,6 +68,7 @@ uint16_t Adafruit_USBD_I2C::getInterfaceDescriptor(uint8_t itfnum_deprecated, ui
   uint8_t itfnum = 0;
   uint8_t ep_in = 0;
   uint8_t ep_out = 0;
+  (void) itfnum_deprecated;
 
   // null buffer is used to get the length of descriptor only
   if (buf) {


### PR DESCRIPTION
Fixes GCC 12 warning for unused parameter found in CI [here](https://productionresultssa0.blob.core.windows.net/actions-results/86f8a27f-af5f-41d2-ac6a-ab59c6755d8e/workflow-job-run-77c9e3e1-c72c-50bc-55af-3e7adcee1252/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-03-07T20%3A32%3A23Z&sig=l%2FfxguicbywzgOodDk7iKkFiXcDfjWhvO9lVLQaLCy0%3D&sp=r&spr=https&sr=b&st=2024-03-07T20%3A22%3A18Z&sv=2021-12-02): 
````
/home/runner/work/arduino-pico/arduino-pico/libraries/Adafruit_TinyUSB_Arduino/examples/Vendor/i2c_tiny_usb_adapter/Adafruit_USBD_I2C.cpp:67:60: error: unused parameter 'itfnum_deprecated' [-Werror=unused-parameter]
   67 | uint16_t Adafruit_USBD_I2C::getInterfaceDescriptor(uint8_t itfnum_deprecated, uint8_t* buf, uint16_t bufsize) {
      |                                                    ~~~~~~~~^~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
````
