### PR TITLE
Enable multiple serial over usb for rp2040

### DIFF
--- a/src/arduino/ports/rp2040/tusb_config_rp2040.h
+++ b/src/arduino/ports/rp2040/tusb_config_rp2040.h
@@ -82,7 +82,7 @@ extern "C" {
 #define CFG_TUD_ENDPOINT0_SIZE 64
 
 #ifndef CFG_TUD_CDC
-#define CFG_TUD_CDC 1
+#define CFG_TUD_CDC 2
 #endif
 #ifndef CFG_TUD_MSC
 #define CFG_TUD_MSC 1


### PR DESCRIPTION
We utilize multiple serial ports on RP2040 boards.  We do so today by manually editing the library (the change is committed).  I can verify the RP2040 has no problem running multiple USB Serial Interfaces at the same time.

Example below how to initialize in .ino file for 2 Serial ports at same time,
```
#include <Adafruit_TinyUSB.h>
Adafruit_USBD_CDC USBSer1;

// In setup method
// Setup Serial
Serial.begin(115200);
// initialize 2nd CDC interface
USBSer1.begin(3686400);
```