### PR TITLE
force re-enumerate for all examples.

### DIFF
--- a/examples/CDC/cdc_multi/cdc_multi.ino
+++ b/examples/CDC/cdc_multi/cdc_multi.ino
@@ -56,6 +56,13 @@ void setup() {
   // initialize 2nd CDC interface
   USBSer1.begin(115200);
 
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   while (!Serial || !USBSer1) {
     if (Serial) {
       Serial.println("Waiting for other USB ports");

--- a/examples/CDC/no_serial/no_serial.ino
+++ b/examples/CDC/no_serial/no_serial.ino
@@ -31,6 +31,13 @@ void setup()
   // clear configuration will remove all USB interfaces including CDC (Serial)
   TinyUSBDevice.clearConfiguration();
 
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   pinMode(led, OUTPUT);
 }
 

--- a/examples/Composite/mouse_ramdisk/mouse_ramdisk.ino
+++ b/examples/Composite/mouse_ramdisk/mouse_ramdisk.ino
@@ -74,6 +74,8 @@ void setup() {
     TinyUSBDevice.begin(0);
   }
 
+  Serial.begin(115200);
+
   // Set disk vendor id, product id and revision with string up to 8, 16, 4 characters respectively
   usb_msc.setID("Adafruit", "Mass Storage", "1.0");
 
@@ -97,7 +99,13 @@ void setup() {
   usb_hid.setPollInterval(2);
   usb_hid.begin();
 
-  Serial.begin(115200);
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   Serial.println("Adafruit TinyUSB Mouse + Mass Storage (ramdisk) example");
 }
 

--- a/examples/HID/hid_boot_keyboard/hid_boot_keyboard.ino
+++ b/examples/HID/hid_boot_keyboard/hid_boot_keyboard.ino
@@ -66,6 +66,13 @@ void setup() {
 
   usb_hid.begin();
 
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   // led pin
   pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, LOW);

--- a/examples/HID/hid_boot_mouse/hid_boot_mouse.ino
+++ b/examples/HID/hid_boot_mouse/hid_boot_mouse.ino
@@ -59,6 +59,8 @@ void setup() {
     TinyUSBDevice.begin(0);
   }
 
+  Serial.begin(115200);
+
   // Set up button, pullup opposite to active state
   pinMode(pin, activeState ? INPUT_PULLDOWN : INPUT_PULLUP);
 
@@ -67,10 +69,15 @@ void setup() {
   usb_hid.setPollInterval(2);
   usb_hid.setReportDescriptor(desc_hid_report, sizeof(desc_hid_report));
   usb_hid.setStringDescriptor("TinyUSB Mouse");
-
   usb_hid.begin();
 
-  Serial.begin(115200);
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   Serial.println("Adafruit TinyUSB HID Mouse example");
 }
 

--- a/examples/HID/hid_composite/hid_composite.ino
+++ b/examples/HID/hid_composite/hid_composite.ino
@@ -70,17 +70,24 @@ void setup() {
     TinyUSBDevice.begin(0);
   }
 
+  Serial.begin(115200);
+
   // Set up HID
   usb_hid.setPollInterval(2);
   usb_hid.setReportDescriptor(desc_hid_report, sizeof(desc_hid_report));
   usb_hid.setStringDescriptor("TinyUSB HID Composite");
-
   usb_hid.begin();
+
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
 
   // Set up button, pullup opposite to active state
   pinMode(pin, activeState ? INPUT_PULLDOWN : INPUT_PULLUP);
 
-  Serial.begin(115200);
   Serial.println("Adafruit TinyUSB HID Composite example");
 }
 

--- a/examples/HID/hid_composite_joy_featherwing/hid_composite_joy_featherwing.ino
+++ b/examples/HID/hid_composite_joy_featherwing/hid_composite_joy_featherwing.ino
@@ -56,13 +56,20 @@ void setup() {
   if (!TinyUSBDevice.isInitialized()) {
     TinyUSBDevice.begin(0);
   }
+  Serial.begin(115200);
 
   // Notes: following commented-out functions has no affect on ESP32
   // usb_hid.setPollInterval(2);
   // usb_hid.setReportDescriptor(desc_hid_report, sizeof(desc_hid_report));
   usb_hid.begin();
 
-  Serial.begin(115200);
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   Serial.println("Adafruit TinyUSB HID Mouse with Joy FeatherWing example");
 
   if (!ss.begin(0x49)) {

--- a/examples/HID/hid_dual_interfaces/hid_dual_interfaces.ino
+++ b/examples/HID/hid_dual_interfaces/hid_dual_interfaces.ino
@@ -67,6 +67,8 @@ void setup() {
     TinyUSBDevice.begin(0);
   }
 
+  Serial.begin(115200);
+
   // HID Keyboard
   usb_keyboard.setPollInterval(2);
   usb_keyboard.setBootProtocol(HID_ITF_PROTOCOL_KEYBOARD);
@@ -81,10 +83,16 @@ void setup() {
   usb_mouse.setStringDescriptor("TinyUSB HID Keyboard");
   usb_mouse.begin();
 
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   // Set up button, pullup opposite to active state
   pinMode(pin, activeState ? INPUT_PULLDOWN : INPUT_PULLUP);
 
-  Serial.begin(115200);
   Serial.println("Adafruit TinyUSB HID Composite example");
 }
 

--- a/examples/HID/hid_gamepad/hid_gamepad.ino
+++ b/examples/HID/hid_gamepad/hid_gamepad.ino
@@ -47,6 +47,13 @@ void setup() {
   usb_hid.setReportDescriptor(desc_hid_report, sizeof(desc_hid_report));
   usb_hid.begin();
 
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   Serial.println("Adafruit TinyUSB HID Gamepad example");
 }
 

--- a/examples/HID/hid_generic_inout/hid_generic_inout.ino
+++ b/examples/HID/hid_generic_inout/hid_generic_inout.ino
@@ -53,16 +53,23 @@ void setup() {
     TinyUSBDevice.begin(0);
   }
 
+  Serial.begin(115200);
+
   // Notes: following commented-out functions has no affect on ESP32
   usb_hid.enableOutEndpoint(true);
   usb_hid.setPollInterval(2);
   usb_hid.setReportDescriptor(desc_hid_report, sizeof(desc_hid_report));
   usb_hid.setStringDescriptor("TinyUSB HID Generic");
-
   usb_hid.setReportCallback(get_report_callback, set_report_callback);
   usb_hid.begin();
 
-  Serial.begin(115200);
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   Serial.println("Adafruit TinyUSB HID Generic In Out example");
 }
 

--- a/examples/MIDI/midi_multi_ports/midi_multi_ports.ino
+++ b/examples/MIDI/midi_multi_ports/midi_multi_ports.ino
@@ -19,8 +19,7 @@
 // USB MIDI object with 3 ports
 Adafruit_USBD_MIDI usb_midi(3);
 
-void setup()
-{
+void setup() {
   pinMode(LED_BUILTIN, OUTPUT);
 
   // Manual begin() is required on core without built-in support e.g. mbed rp2040
@@ -32,12 +31,17 @@ void setup()
   usb_midi.setCableName(1, "Keyboard");
   usb_midi.setCableName(2, "Drum Pads");
   usb_midi.setCableName(3, "Lights");
-
   usb_midi.begin();
+
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
 }
 
-void loop()
-{
+void loop() {
   #ifdef TINYUSB_NEED_POLLING_TASK
   // Manual call tud_task since it isn't called by Core's background
   TinyUSBDevice.task();

--- a/examples/MIDI/midi_test/midi_test.ino
+++ b/examples/MIDI/midi_test/midi_test.ino
@@ -42,6 +42,8 @@ void setup() {
     TinyUSBDevice.begin(0);
   }
 
+  Serial.begin(115200);
+
   pinMode(LED_BUILTIN, OUTPUT);
 
   usb_midi.setStringDescriptor("TinyUSB MIDI");
@@ -50,14 +52,19 @@ void setup() {
   // This will also call usb_midi's begin()
   MIDI.begin(MIDI_CHANNEL_OMNI);
 
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   // Attach the handleNoteOn function to the MIDI Library. It will
   // be called whenever the Bluefruit receives MIDI Note On messages.
   MIDI.setHandleNoteOn(handleNoteOn);
 
   // Do the same for MIDI Note Off messages.
   MIDI.setHandleNoteOff(handleNoteOff);
-
-  Serial.begin(115200);
 }
 
 void loop() {

--- a/examples/MassStorage/msc_esp32_file_browser/msc_esp32_file_browser.ino
+++ b/examples/MassStorage/msc_esp32_file_browser/msc_esp32_file_browser.ino
@@ -93,14 +93,19 @@ void setupMassStorage(void)
   // MSC is ready for read/write
   fs_changed = false;
   usb_msc.setReadyCallback(0, msc_ready_callback);
-
   usb_msc.begin();
+
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
 
   // Init file system on the flash
   fs_formatted = fatfs.begin(&flash);
 
-  if ( !fs_formatted )
-  {
+  if ( !fs_formatted ) {
     DBG_SERIAL.println("Failed to init files system, flash may not be formatted");
   }
 }

--- a/examples/MassStorage/msc_external_flash_sdcard/msc_external_flash_sdcard.ino
+++ b/examples/MassStorage/msc_external_flash_sdcard/msc_external_flash_sdcard.ino
@@ -66,8 +66,7 @@ bool flash_formatted = false;
 bool flash_changed = false;
 
 // the setup function runs once when you press reset or power the board
-void setup()
-{
+void setup() {
   pinMode(LED_BUILTIN, OUTPUT);
   Serial.begin(115200);
 
@@ -82,6 +81,13 @@ void setup()
   // i.e without Mass Storage. To prevent this, we call Mass Storage begin first
   // LUN readiness will always be set later on
   usb_msc.begin();
+
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
 
   //------------- Lun 0 for external flash -------------//
   flash.begin();

--- a/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
+++ b/examples/MassStorage/msc_ramdisk/msc_ramdisk.ino
@@ -42,6 +42,8 @@ void setup() {
     TinyUSBDevice.begin(0);
   }
 
+  Serial.begin(115200);
+
 #ifdef BTN_EJECT
   pinMode(BTN_EJECT, activeState ? INPUT_PULLDOWN : INPUT_PULLUP);
 #endif
@@ -61,9 +63,14 @@ void setup() {
   usb_msc.setUnitReady(true);
   usb_msc.begin();
 
-  Serial.begin(115200);
-//  while ( !Serial ) delay(10);   // wait for native usb
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
 
+//  while ( !Serial ) delay(10);   // wait for native usb
   Serial.println("Adafruit TinyUSB Mass Storage RAM Disk example");
 }
 

--- a/examples/MassStorage/msc_ramdisk_dual/msc_ramdisk_dual.ino
+++ b/examples/MassStorage/msc_ramdisk_dual/msc_ramdisk_dual.ino
@@ -26,6 +26,8 @@ void setup() {
     TinyUSBDevice.begin(0);
   }
 
+  Serial.begin(115200);
+
   usb_msc.setMaxLun(2);
 
   // Set disk size and callback for Logical Unit 0 (LUN 0)
@@ -42,9 +44,14 @@ void setup() {
 
   usb_msc.begin();
 
-  Serial.begin(115200);
-  //while ( !Serial ) delay(10);   // wait for native usb
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
 
+  //while ( !Serial ) delay(10);   // wait for native usb
   Serial.println("Adafruit TinyUSB Mass Storage Dual RAM Disks example");
 }
 

--- a/examples/MassStorage/msc_sd/msc_sd.ino
+++ b/examples/MassStorage/msc_sd/msc_sd.ino
@@ -26,6 +26,8 @@ SdVolume volume;
 // the setup function runs once when you press reset or power the board
 void setup()
 {
+  Serial.begin(115200);
+
   // Set disk vendor id, product id and revision with string up to 8, 16, 4 characters respectively
   usb_msc.setID("Adafruit", "SD Card", "1.0");
 
@@ -37,15 +39,18 @@ void setup()
   usb_msc.setUnitReady(false);
   usb_msc.begin();
 
-  Serial.begin(115200);
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   //while ( !Serial ) delay(10);   // wait for native usb
-
   Serial.println("Adafruit TinyUSB Mass Storage SD Card example");
-
   Serial.println("\nInitializing SD card...");
 
-  if ( !card.init(SPI_HALF_SPEED, chipSelect) )
-  {
+  if ( !card.init(SPI_HALF_SPEED, chipSelect) ) {
     Serial.println("initialization failed. Things to check:");
     Serial.println("* is a card inserted?");
     Serial.println("* is your wiring correct?");
@@ -71,16 +76,14 @@ void setup()
   usb_msc.setUnitReady(true);
 }
 
-void loop()
-{
+void loop() {
   // nothing to do
 }
 
 // Callback invoked when received READ10 command.
 // Copy disk's data to buffer (up to bufsize) and
 // return number of copied bytes (must be multiple of block size)
-int32_t msc_read_cb (uint32_t lba, void* buffer, uint32_t bufsize)
-{
+int32_t msc_read_cb (uint32_t lba, void* buffer, uint32_t bufsize) {
   (void) bufsize;
   return card.readBlock(lba, (uint8_t*) buffer) ? 512 : -1;
 }
@@ -88,15 +91,13 @@ int32_t msc_read_cb (uint32_t lba, void* buffer, uint32_t bufsize)
 // Callback invoked when received WRITE10 command.
 // Process data in buffer to disk's storage and 
 // return number of written bytes (must be multiple of block size)
-int32_t msc_write_cb (uint32_t lba, uint8_t* buffer, uint32_t bufsize)
-{
+int32_t msc_write_cb (uint32_t lba, uint8_t* buffer, uint32_t bufsize) {
   (void) bufsize;
   return card.writeBlock(lba, buffer) ? 512 : -1;
 }
 
 // Callback invoked when WRITE10 command is completed (status received and accepted by host).
 // used to flush any pending cache.
-void msc_flush_cb (void)
-{
+void msc_flush_cb (void) {
   // nothing to do
 }

--- a/examples/MassStorage/msc_sdfat/msc_sdfat.ino
+++ b/examples/MassStorage/msc_sdfat/msc_sdfat.ino
@@ -34,6 +34,8 @@ bool fs_changed;
 // the setup function runs once when you press reset or power the board
 void setup()
 {
+  Serial.begin(115200);
+
   pinMode(LED_BUILTIN, OUTPUT);
 
   // Set disk vendor id, product id and revision with string up to 8, 16, 4 characters respectively
@@ -47,16 +49,19 @@ void setup()
   usb_msc.setUnitReady(false);
   usb_msc.begin();
 
-  Serial.begin(115200);
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
+
   //while ( !Serial ) delay(10);   // wait for native usb
-
   Serial.println("Adafruit TinyUSB Mass Storage SD Card example");
-
   Serial.print("\nInitializing SD card ... ");
   Serial.print("CS = "); Serial.println(chipSelect);
 
-  if ( !sd.begin(chipSelect, SD_SCK_MHZ(50)) )
-  {
+  if ( !sd.begin(chipSelect, SD_SCK_MHZ(50)) ) {
     Serial.println("initialization failed. Things to check:");
     Serial.println("* is a card inserted?");
     Serial.println("* is your wiring correct?");
@@ -83,23 +88,19 @@ void setup()
   fs_changed = true; // to print contents initially
 }
 
-void loop()
-{
-  if ( fs_changed )
-  {
+void loop() {
+  if ( fs_changed ) {
     root.open("/");
     Serial.println("SD contents:");
 
     // Open next file in root.
     // Warning, openNext starts at the current directory position
     // so a rewind of the directory may be required.
-    while ( file.openNext(&root, O_RDONLY) )
-    {
+    while ( file.openNext(&root, O_RDONLY) ) {
       file.printFileSize(&Serial);
       Serial.write(' ');
       file.printName(&Serial);
-      if ( file.isDir() )
-      {
+      if ( file.isDir() ) {
         // Indicate a directory.
         Serial.write('/');
       }
@@ -119,8 +120,7 @@ void loop()
 // Callback invoked when received READ10 command.
 // Copy disk's data to buffer (up to bufsize) and
 // return number of copied bytes (must be multiple of block size)
-int32_t msc_read_cb (uint32_t lba, void* buffer, uint32_t bufsize)
-{
+int32_t msc_read_cb (uint32_t lba, void* buffer, uint32_t bufsize) {
   bool rc;
 
 #if SD_FAT_VERSION >= 20000
@@ -135,8 +135,7 @@ int32_t msc_read_cb (uint32_t lba, void* buffer, uint32_t bufsize)
 // Callback invoked when received WRITE10 command.
 // Process data in buffer to disk's storage and 
 // return number of written bytes (must be multiple of block size)
-int32_t msc_write_cb (uint32_t lba, uint8_t* buffer, uint32_t bufsize)
-{
+int32_t msc_write_cb (uint32_t lba, uint8_t* buffer, uint32_t bufsize) {
   bool rc;
 
   digitalWrite(LED_BUILTIN, HIGH);
@@ -152,8 +151,7 @@ int32_t msc_write_cb (uint32_t lba, uint8_t* buffer, uint32_t bufsize)
 
 // Callback invoked when WRITE10 command is completed (status received and accepted by host).
 // used to flush any pending cache.
-void msc_flush_cb (void)
-{
+void msc_flush_cb (void) {
 #if SD_FAT_VERSION >= 20000
   sd.card()->syncDevice();
 #else

--- a/examples/Vendor/i2c_tiny_usb_adapter/i2c_tiny_usb_adapter.ino
+++ b/examples/Vendor/i2c_tiny_usb_adapter/i2c_tiny_usb_adapter.ino
@@ -63,6 +63,13 @@ void setup() {
 
   // init i2c usb with buffer and size
   i2c_usb.begin(i2c_buf, sizeof(i2c_buf));
+
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
 }
 
 void loop() {

--- a/examples/Video/video_capture/video_capture.ino
+++ b/examples/Video/video_capture/video_capture.ino
@@ -134,6 +134,13 @@ void setup() {
   usb_video.addColorMatching(&desc_color);
 
   usb_video.begin();
+
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
 }
 
 void loop() {

--- a/examples/WebUSB/webusb_rgb/webusb_rgb.ino
+++ b/examples/WebUSB/webusb_rgb/webusb_rgb.ino
@@ -59,12 +59,20 @@ void setup() {
   if (!TinyUSBDevice.isInitialized()) {
     TinyUSBDevice.begin(0);
   }
+
+  Serial.begin(115200);
+
   //usb_web.setStringDescriptor("TinyUSB WebUSB");
   usb_web.setLandingPage(&landingPage);
   usb_web.setLineStateCallback(line_state_callback);
   usb_web.begin();
 
-  Serial.begin(115200);
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
 
   // This initializes the NeoPixel with RED
 #ifdef NEOPIXEL_POWER

--- a/examples/WebUSB/webusb_serial/webusb_serial.ino
+++ b/examples/WebUSB/webusb_serial/webusb_serial.ino
@@ -42,6 +42,7 @@ void setup() {
   if (!TinyUSBDevice.isInitialized()) {
     TinyUSBDevice.begin(0);
   }
+  Serial.begin(115200);
 
   pinMode(led_pin, OUTPUT);
   digitalWrite(led_pin, LOW);
@@ -51,7 +52,12 @@ void setup() {
   //usb_web.setStringDescriptor("TinyUSB WebUSB");
   usb_web.begin();
 
-  Serial.begin(115200);
+  // If already enumerated, additional class driverr begin() e.g msc, hid, midi won't take effect until re-enumeration
+  if (TinyUSBDevice.mounted()) {
+    TinyUSBDevice.detach();
+    delay(10);
+    TinyUSBDevice.attach();
+  }
 
   // wait until device mounted
   while (!TinyUSBDevice.mounted()) delay(1);


### PR DESCRIPTION
For some fast chip such as esp32-s3, by the time we initialize class driver enumeration process is already done. Therefore we will need to force re-enumeration using disconnect/connect. Should fix https://github.com/adafruit/Adafruit_TinyUSB_Arduino/issues/436