### PR TITLE
add Adafruit_USBD_CDC::ignoreFlowControl

### DIFF
--- a/src/arduino/Adafruit_USBD_CDC.cpp
+++ b/src/arduino/Adafruit_USBD_CDC.cpp
@@ -118,6 +118,10 @@ void Adafruit_USBD_CDC::end(void) {
   _instance = INVALID_INSTANCE;
 }
 
+void Adafruit_USBD_CDC::ignoreFlowControl(bool ignore) {
+  _ignoreFlowControl = ignore;
+}
+
 uint32_t Adafruit_USBD_CDC::baud(void) {
   if (!isValid()) {
     return 0;
@@ -243,7 +247,7 @@ size_t Adafruit_USBD_CDC::write(const uint8_t *buffer, size_t size) {
   }
 
   size_t remain = size;
-  while (remain && tud_cdc_n_connected(_instance)) {
+  while (remain && (tud_cdc_n_connected(_instance) || _ignoreFlowControl)) {
     size_t wrcount = tud_cdc_n_write(_instance, buffer, remain);
     remain -= wrcount;
     buffer += wrcount;

--- a/src/arduino/Adafruit_USBD_CDC.h
+++ b/src/arduino/Adafruit_USBD_CDC.h
@@ -54,6 +54,14 @@ public:
   void begin(uint32_t baud, uint8_t config);
   void end(void);
 
+  // In some cases, the target application will not assert
+  // the DTR virtual line, thus preventing writing operations
+  // to succeed. For this reason, the
+  // Adafruit_USBD_CDC::ignoreFlowControl() method disables the
+  // connection’s state verification, enabling the program to
+  // write on the port, even though the data might be lost.
+  void ignoreFlowControl(bool ignore = true);
+
   // return line coding set by host
   uint32_t baud(void);
   uint8_t stopbits(void);
@@ -89,6 +97,8 @@ private:
   static uint8_t _instance_count;
 
   uint8_t _instance;
+
+  bool _ignoreFlowControl = false;
 
   bool isValid(void) { return _instance != INVALID_INSTANCE; }
 };


### PR DESCRIPTION
In some cases, the target application will not assert the DTR virtual line, thus preventing writing operations to succeed.
For this reason, the Adafruit_USBD_CDC::ignoreFlowControl() method disables the connection’s state verification, enabling the program to write on the port, even though the data might be lost.