### PR TITLE
update tinyusb to fix esp32 build with v3.0.7

### DIFF
--- a/src/class/audio/audio_device.c
+++ b/src/class/audio/audio_device.c
@@ -2071,8 +2071,8 @@ static bool audiod_set_interface(uint8_t rhport, tusb_control_request_t const * 
             // Avoid 64bit division
             uint32_t nominal = ((fb_param.sample_freq / 100) << 16) / (frame_div / 100);
             audio->feedback.compute.fifo_count.nom_value = nominal;
-            audio->feedback.compute.fifo_count.rate_const[0] = (audio->feedback.max_value - nominal) / fifo_lvl_thr;
-            audio->feedback.compute.fifo_count.rate_const[1] = (nominal - audio->feedback.min_value) / fifo_lvl_thr;
+            audio->feedback.compute.fifo_count.rate_const[0] = (uint16_t) ((audio->feedback.max_value - nominal) / fifo_lvl_thr);
+            audio->feedback.compute.fifo_count.rate_const[1] = (uint16_t) ((nominal - audio->feedback.min_value) / fifo_lvl_thr);
             // On HS feedback is more sensitive since packet size can vary every MSOF, could cause instability
             if(tud_speed_get() == TUSB_SPEED_HIGH) {
               audio->feedback.compute.fifo_count.rate_const[0] /= 8;
@@ -2381,11 +2381,11 @@ static bool audiod_set_fb_params_freq(audiod_function_t* audio, uint32_t sample_
   if ((mclk_freq % sample_freq) == 0 && tu_is_power_of_two(mclk_freq / sample_freq))
   {
     audio->feedback.compute_method     = AUDIO_FEEDBACK_METHOD_FREQUENCY_POWER_OF_2;
-    audio->feedback.compute.power_of_2 = 16 - (audio->feedback.frame_shift - 1) - tu_log2(mclk_freq / sample_freq);
+    audio->feedback.compute.power_of_2 = (uint8_t) (16 - (audio->feedback.frame_shift - 1) - tu_log2(mclk_freq / sample_freq));
   }
   else if ( audio->feedback.compute_method == AUDIO_FEEDBACK_METHOD_FREQUENCY_FLOAT)
   {
-    audio->feedback.compute.float_const = (float)sample_freq / mclk_freq * (1UL << (16 - (audio->feedback.frame_shift - 1)));
+    audio->feedback.compute.float_const = (float)sample_freq / (float) mclk_freq * (1UL << (16 - (audio->feedback.frame_shift - 1)));
   }
   else
   {

--- a/src/class/cdc/cdc_device.h
+++ b/src/class/cdc/cdc_device.h
@@ -24,8 +24,8 @@
  * This file is part of the TinyUSB stack.
  */
 
-#ifndef _TUSB_CDC_DEVICE_H_
-#define _TUSB_CDC_DEVICE_H_
+#ifndef TUSB_CDC_DEVICE_H_
+#define TUSB_CDC_DEVICE_H_
 
 #include "cdc.h"
 

--- a/src/class/cdc/cdc_host.c
+++ b/src/class/cdc/cdc_host.c
@@ -373,14 +373,14 @@ uint32_t tuh_cdc_write(uint8_t idx, void const* buffer, uint32_t bufsize) {
   cdch_interface_t* p_cdc = get_itf(idx);
   TU_VERIFY(p_cdc);
 
-  return tu_edpt_stream_write(&p_cdc->stream.tx, buffer, bufsize);
+  return tu_edpt_stream_write(p_cdc->daddr, &p_cdc->stream.tx, buffer, bufsize);
 }
 
 uint32_t tuh_cdc_write_flush(uint8_t idx) {
   cdch_interface_t* p_cdc = get_itf(idx);
   TU_VERIFY(p_cdc);
 
-  return tu_edpt_stream_write_xfer(&p_cdc->stream.tx);
+  return tu_edpt_stream_write_xfer(p_cdc->daddr, &p_cdc->stream.tx);
 }
 
 bool tuh_cdc_write_clear(uint8_t idx) {
@@ -394,7 +394,7 @@ uint32_t tuh_cdc_write_available(uint8_t idx) {
   cdch_interface_t* p_cdc = get_itf(idx);
   TU_VERIFY(p_cdc);
 
-  return tu_edpt_stream_write_available(&p_cdc->stream.tx);
+  return tu_edpt_stream_write_available(p_cdc->daddr, &p_cdc->stream.tx);
 }
 
 //--------------------------------------------------------------------+
@@ -405,7 +405,7 @@ uint32_t tuh_cdc_read (uint8_t idx, void* buffer, uint32_t bufsize) {
   cdch_interface_t* p_cdc = get_itf(idx);
   TU_VERIFY(p_cdc);
 
-  return tu_edpt_stream_read(&p_cdc->stream.rx, buffer, bufsize);
+  return tu_edpt_stream_read(p_cdc->daddr, &p_cdc->stream.rx, buffer, bufsize);
 }
 
 uint32_t tuh_cdc_read_available(uint8_t idx) {
@@ -427,7 +427,7 @@ bool tuh_cdc_read_clear (uint8_t idx) {
   TU_VERIFY(p_cdc);
 
   bool ret = tu_edpt_stream_clear(&p_cdc->stream.rx);
-  tu_edpt_stream_read_xfer(&p_cdc->stream.rx);
+  tu_edpt_stream_read_xfer(p_cdc->daddr, &p_cdc->stream.rx);
   return ret;
 }
 
@@ -709,10 +709,10 @@ bool cdch_xfer_cb(uint8_t daddr, uint8_t ep_addr, xfer_result_t event, uint32_t 
     // invoke tx complete callback to possibly refill tx fifo
     if (tuh_cdc_tx_complete_cb) tuh_cdc_tx_complete_cb(idx);
 
-    if ( 0 == tu_edpt_stream_write_xfer(&p_cdc->stream.tx) ) {
+    if ( 0 == tu_edpt_stream_write_xfer(daddr, &p_cdc->stream.tx) ) {
       // If there is no data left, a ZLP should be sent if:
       // - xferred_bytes is multiple of EP Packet size and not zero
-      tu_edpt_stream_write_zlp_if_needed(&p_cdc->stream.tx, xferred_bytes);
+      tu_edpt_stream_write_zlp_if_needed(daddr, &p_cdc->stream.tx, xferred_bytes);
     }
   } else if ( ep_addr == p_cdc->stream.rx.ep_addr ) {
     #if CFG_TUH_CDC_FTDI
@@ -730,7 +730,7 @@ bool cdch_xfer_cb(uint8_t daddr, uint8_t ep_addr, xfer_result_t event, uint32_t 
     if (tuh_cdc_rx_cb) tuh_cdc_rx_cb(idx);
 
     // prepare for next transfer if needed
-    tu_edpt_stream_read_xfer(&p_cdc->stream.rx);
+    tu_edpt_stream_read_xfer(daddr, &p_cdc->stream.rx);
   }else if ( ep_addr == p_cdc->ep_notif ) {
     // TODO handle notification endpoint
   }else {
@@ -751,9 +751,9 @@ static bool open_ep_stream_pair(cdch_interface_t* p_cdc, tusb_desc_endpoint_t co
     TU_ASSERT(tuh_edpt_open(p_cdc->daddr, desc_ep));
 
     if (tu_edpt_dir(desc_ep->bEndpointAddress) == TUSB_DIR_IN) {
-      tu_edpt_stream_open(&p_cdc->stream.rx, p_cdc->daddr, desc_ep);
+      tu_edpt_stream_open(&p_cdc->stream.rx, desc_ep);
     } else {
-      tu_edpt_stream_open(&p_cdc->stream.tx, p_cdc->daddr, desc_ep);
+      tu_edpt_stream_open(&p_cdc->stream.tx, desc_ep);
     }
 
     desc_ep = (tusb_desc_endpoint_t const*) tu_desc_next(desc_ep);
@@ -795,7 +795,7 @@ static void set_config_complete(cdch_interface_t * p_cdc, uint8_t idx, uint8_t i
   if (tuh_cdc_mount_cb) tuh_cdc_mount_cb(idx);
 
   // Prepare for incoming data
-  tu_edpt_stream_read_xfer(&p_cdc->stream.rx);
+  tu_edpt_stream_read_xfer(p_cdc->daddr, &p_cdc->stream.rx);
 
   // notify usbh that driver enumeration is complete
   usbh_driver_set_config_complete(p_cdc->daddr, itf_num);

--- a/src/class/vendor/vendor_device.c
+++ b/src/class/vendor/vendor_device.c
@@ -41,136 +41,103 @@
 //--------------------------------------------------------------------+
 // MACRO CONSTANT TYPEDEF
 //--------------------------------------------------------------------+
-#define BULK_PACKET_SIZE (TUD_OPT_HIGH_SPEED ? 512 : 64)
-
-typedef struct
-{
+typedef struct {
   uint8_t itf_num;
-  uint8_t ep_in;
-  uint8_t ep_out;
 
   /*------------- From this point, data is not cleared by bus reset -------------*/
-  tu_fifo_t rx_ff;
-  tu_fifo_t tx_ff;
-
-  uint8_t rx_ff_buf[CFG_TUD_VENDOR_RX_BUFSIZE];
-  uint8_t tx_ff_buf[CFG_TUD_VENDOR_TX_BUFSIZE];
-
-  OSAL_MUTEX_DEF(rx_ff_mutex);
-  OSAL_MUTEX_DEF(tx_ff_mutex);
-
   // Endpoint Transfer buffer
-  CFG_TUSB_MEM_ALIGN uint8_t epout_buf[CFG_TUD_VENDOR_EPSIZE];
-  CFG_TUSB_MEM_ALIGN uint8_t epin_buf[CFG_TUD_VENDOR_EPSIZE];
+  CFG_TUD_MEM_ALIGN uint8_t epout_buf[CFG_TUD_VENDOR_EPSIZE];
+  CFG_TUD_MEM_ALIGN uint8_t epin_buf[CFG_TUD_VENDOR_EPSIZE];
+
+  struct {
+    tu_edpt_stream_t stream;
+    #if CFG_TUD_VENDOR_TX_BUFSIZE > 0
+    uint8_t ff_buf[CFG_TUD_VENDOR_TX_BUFSIZE];
+    #endif
+  }tx;
+
+  struct {
+    tu_edpt_stream_t stream;
+    #if CFG_TUD_VENDOR_RX_BUFSIZE > 0
+    uint8_t ff_buf[CFG_TUD_VENDOR_RX_BUFSIZE];
+    #endif
+  } rx;
+
 } vendord_interface_t;
 
-CFG_TUD_MEM_SECTION tu_static vendord_interface_t _vendord_itf[CFG_TUD_VENDOR];
+CFG_TUD_MEM_SECTION static vendord_interface_t _vendord_itf[CFG_TUD_VENDOR];
 
-#define ITF_MEM_RESET_SIZE   offsetof(vendord_interface_t, rx_ff)
+#define ITF_MEM_RESET_SIZE   (offsetof(vendord_interface_t, itf_num) + sizeof(((vendord_interface_t *)0)->itf_num))
 
+//--------------------------------------------------------------------
+// Application API
+//--------------------------------------------------------------------
 
-bool tud_vendor_n_mounted (uint8_t itf)
-{
-  return _vendord_itf[itf].ep_in && _vendord_itf[itf].ep_out;
-}
-
-uint32_t tud_vendor_n_available (uint8_t itf)
-{
-  return tu_fifo_count(&_vendord_itf[itf].rx_ff);
-}
-
-bool tud_vendor_n_peek(uint8_t itf, uint8_t* u8)
-{
-  return tu_fifo_peek(&_vendord_itf[itf].rx_ff, u8);
+bool tud_vendor_n_mounted(uint8_t itf) {
+  TU_VERIFY(itf < CFG_TUD_VENDOR);
+  vendord_interface_t* p_itf = &_vendord_itf[itf];
+  return p_itf->rx.stream.ep_addr || p_itf->tx.stream.ep_addr;
 }
 
 //--------------------------------------------------------------------+
 // Read API
 //--------------------------------------------------------------------+
-static void _prep_out_transaction (vendord_interface_t* p_itf)
-{
+uint32_t tud_vendor_n_available(uint8_t itf) {
+  TU_VERIFY(itf < CFG_TUD_VENDOR, 0);
+  vendord_interface_t* p_itf = &_vendord_itf[itf];
+
+  return tu_edpt_stream_read_available(&p_itf->rx.stream);
+}
+
+bool tud_vendor_n_peek(uint8_t itf, uint8_t* u8) {
+  TU_VERIFY(itf < CFG_TUD_VENDOR);
+  vendord_interface_t* p_itf = &_vendord_itf[itf];
+
+  return tu_edpt_stream_peek(&p_itf->rx.stream, u8);
+}
+
+uint32_t tud_vendor_n_read (uint8_t itf, void* buffer, uint32_t bufsize) {
+  TU_VERIFY(itf < CFG_TUD_VENDOR, 0);
+  vendord_interface_t* p_itf = &_vendord_itf[itf];
   uint8_t const rhport = 0;
 
-    // claim endpoint
-  TU_VERIFY(usbd_edpt_claim(rhport, p_itf->ep_out), );
-
-  // Prepare for incoming data but only allow what we can store in the ring buffer.
-  uint16_t max_read = tu_fifo_remaining(&p_itf->rx_ff);
-  if ( max_read >= CFG_TUD_VENDOR_EPSIZE )
-  {
-    usbd_edpt_xfer(rhport, p_itf->ep_out, p_itf->epout_buf, CFG_TUD_VENDOR_EPSIZE);
-  }
-  else
-  {
-    // Release endpoint since we don't make any transfer
-    usbd_edpt_release(rhport, p_itf->ep_out);
-  }
+  return tu_edpt_stream_read(rhport, &p_itf->rx.stream, buffer, bufsize);
 }
 
-uint32_t tud_vendor_n_read (uint8_t itf, void* buffer, uint32_t bufsize)
-{
+void tud_vendor_n_read_flush (uint8_t itf) {
+  TU_VERIFY(itf < CFG_TUD_VENDOR, );
   vendord_interface_t* p_itf = &_vendord_itf[itf];
-  uint32_t num_read = tu_fifo_read_n(&p_itf->rx_ff, buffer, (uint16_t) bufsize);
-  _prep_out_transaction(p_itf);
-  return num_read;
-}
+  uint8_t const rhport = 0;
 
-void tud_vendor_n_read_flush (uint8_t itf)
-{
-  vendord_interface_t* p_itf = &_vendord_itf[itf];
-  tu_fifo_clear(&p_itf->rx_ff);
-  _prep_out_transaction(p_itf);
+  tu_edpt_stream_clear(&p_itf->rx.stream);
+  tu_edpt_stream_read_xfer(rhport, &p_itf->rx.stream);
 }
 
 //--------------------------------------------------------------------+
 // Write API
 //--------------------------------------------------------------------+
-uint32_t tud_vendor_n_write (uint8_t itf, void const* buffer, uint32_t bufsize)
-{
+uint32_t tud_vendor_n_write (uint8_t itf, void const* buffer, uint32_t bufsize) {
+  TU_VERIFY(itf < CFG_TUD_VENDOR, 0);
   vendord_interface_t* p_itf = &_vendord_itf[itf];
-  uint16_t ret = tu_fifo_write_n(&p_itf->tx_ff, buffer, (uint16_t) bufsize);
-
-  // flush if queue more than packet size
-  if (tu_fifo_count(&p_itf->tx_ff) >= CFG_TUD_VENDOR_EPSIZE) {
-    tud_vendor_n_write_flush(itf);
-  }
-  return ret;
-}
-
-uint32_t tud_vendor_n_write_flush (uint8_t itf)
-{
-  vendord_interface_t* p_itf = &_vendord_itf[itf];
-
-  // Skip if usb is not ready yet
-  TU_VERIFY( tud_ready(), 0 );
-
-  // No data to send
-  if ( !tu_fifo_count(&p_itf->tx_ff) ) return 0;
-
   uint8_t const rhport = 0;
 
-  // Claim the endpoint
-  TU_VERIFY( usbd_edpt_claim(rhport, p_itf->ep_in), 0 );
-
-  // Pull data from FIFO
-  uint16_t const count = tu_fifo_read_n(&p_itf->tx_ff, p_itf->epin_buf, sizeof(p_itf->epin_buf));
-
-  if ( count )
-  {
-    TU_ASSERT( usbd_edpt_xfer(rhport, p_itf->ep_in, p_itf->epin_buf, count), 0 );
-    return count;
-  }else
-  {
-    // Release endpoint since we don't make any transfer
-    // Note: data is dropped if terminal is not connected
-    usbd_edpt_release(rhport, p_itf->ep_in);
-    return 0;
-  }
+  return tu_edpt_stream_write(rhport, &p_itf->tx.stream, buffer, (uint16_t) bufsize);
 }
 
-uint32_t tud_vendor_n_write_available (uint8_t itf)
-{
-  return tu_fifo_remaining(&_vendord_itf[itf].tx_ff);
+uint32_t tud_vendor_n_write_flush (uint8_t itf) {
+  TU_VERIFY(itf < CFG_TUD_VENDOR, 0);
+  vendord_interface_t* p_itf = &_vendord_itf[itf];
+  uint8_t const rhport = 0;
+
+  return tu_edpt_stream_write_xfer(rhport, &p_itf->tx.stream);
+}
+
+uint32_t tud_vendor_n_write_available (uint8_t itf) {
+  TU_VERIFY(itf < CFG_TUD_VENDOR, 0);
+  vendord_interface_t* p_itf = &_vendord_itf[itf];
+  uint8_t const rhport = 0;
+
+  return tu_edpt_stream_write_available(rhport, &p_itf->tx.stream);
 }
 
 //--------------------------------------------------------------------+
@@ -182,70 +149,61 @@ void vendord_init(void) {
   for(uint8_t i=0; i<CFG_TUD_VENDOR; i++) {
     vendord_interface_t* p_itf = &_vendord_itf[i];
 
-    // config fifo
-    tu_fifo_config(&p_itf->rx_ff, p_itf->rx_ff_buf, CFG_TUD_VENDOR_RX_BUFSIZE, 1, false);
-    tu_fifo_config(&p_itf->tx_ff, p_itf->tx_ff_buf, CFG_TUD_VENDOR_TX_BUFSIZE, 1, false);
+    uint8_t* rx_ff_buf =
+                        #if CFG_TUD_VENDOR_RX_BUFSIZE > 0
+                          p_itf->rx.ff_buf;
+                        #else
+                          NULL;
+                        #endif
 
-    #if OSAL_MUTEX_REQUIRED
-    osal_mutex_t mutex_rd = osal_mutex_create(&p_itf->rx_ff_mutex);
-    osal_mutex_t mutex_wr = osal_mutex_create(&p_itf->tx_ff_mutex);
-    TU_ASSERT(mutex_rd && mutex_wr,);
+    tu_edpt_stream_init(&p_itf->rx.stream, false, false, false,
+                        rx_ff_buf, CFG_TUD_VENDOR_RX_BUFSIZE,
+                        p_itf->epout_buf, CFG_TUD_VENDOR_EPSIZE);
 
-    tu_fifo_config_mutex(&p_itf->rx_ff, NULL, mutex_rd);
-    tu_fifo_config_mutex(&p_itf->tx_ff, mutex_wr, NULL);
-    #endif
+    uint8_t* tx_ff_buf =
+                        #if CFG_TUD_VENDOR_TX_BUFSIZE > 0
+                          p_itf->tx.ff_buf;
+                        #else
+                          NULL;
+                        #endif
+
+    tu_edpt_stream_init(&p_itf->tx.stream, false, true, false,
+                        tx_ff_buf, CFG_TUD_VENDOR_TX_BUFSIZE,
+                        p_itf->epin_buf, CFG_TUD_VENDOR_EPSIZE);
   }
 }
 
 bool vendord_deinit(void) {
-  #if OSAL_MUTEX_REQUIRED
   for(uint8_t i=0; i<CFG_TUD_VENDOR; i++) {
     vendord_interface_t* p_itf = &_vendord_itf[i];
-    osal_mutex_t mutex_rd = p_itf->rx_ff.mutex_rd;
-    osal_mutex_t mutex_wr = p_itf->tx_ff.mutex_wr;
-
-    if (mutex_rd) {
-      osal_mutex_delete(mutex_rd);
-      tu_fifo_config_mutex(&p_itf->rx_ff, NULL, NULL);
-    }
-
-    if (mutex_wr) {
-      osal_mutex_delete(mutex_wr);
-      tu_fifo_config_mutex(&p_itf->tx_ff, NULL, NULL);
-    }
+    tu_edpt_stream_deinit(&p_itf->rx.stream);
+    tu_edpt_stream_deinit(&p_itf->tx.stream);
   }
-  #endif
-
   return true;
 }
 
-void vendord_reset(uint8_t rhport)
-{
+void vendord_reset(uint8_t rhport) {
   (void) rhport;
 
-  for(uint8_t i=0; i<CFG_TUD_VENDOR; i++)
-  {
+  for(uint8_t i=0; i<CFG_TUD_VENDOR; i++) {
     vendord_interface_t* p_itf = &_vendord_itf[i];
-
     tu_memclr(p_itf, ITF_MEM_RESET_SIZE);
-    tu_fifo_clear(&p_itf->rx_ff);
-    tu_fifo_clear(&p_itf->tx_ff);
+    tu_edpt_stream_clear(&p_itf->rx.stream);
+    tu_edpt_stream_clear(&p_itf->tx.stream);
+    tu_edpt_stream_close(&p_itf->rx.stream);
+    tu_edpt_stream_close(&p_itf->tx.stream);
   }
 }
 
-uint16_t vendord_open(uint8_t rhport, tusb_desc_interface_t const * desc_itf, uint16_t max_len)
-{
+uint16_t vendord_open(uint8_t rhport, tusb_desc_interface_t const * desc_itf, uint16_t max_len) {
   TU_VERIFY(TUSB_CLASS_VENDOR_SPECIFIC == desc_itf->bInterfaceClass, 0);
-
-  uint8_t const * p_desc = tu_desc_next(desc_itf);
-  uint8_t const * desc_end = p_desc + max_len;
+  const uint8_t* p_desc = tu_desc_next(desc_itf);
+  const uint8_t* desc_end = p_desc + max_len;
 
   // Find available interface
   vendord_interface_t* p_vendor = NULL;
-  for(uint8_t i=0; i<CFG_TUD_VENDOR; i++)
-  {
-    if ( _vendord_itf[i].ep_in == 0 && _vendord_itf[i].ep_out == 0 )
-    {
+  for(uint8_t i=0; i<CFG_TUD_VENDOR; i++) {
+    if (!tud_vendor_n_mounted(i)) {
       p_vendor = &_vendord_itf[i];
       break;
     }
@@ -253,71 +211,68 @@ uint16_t vendord_open(uint8_t rhport, tusb_desc_interface_t const * desc_itf, ui
   TU_VERIFY(p_vendor, 0);
 
   p_vendor->itf_num = desc_itf->bInterfaceNumber;
-  if (desc_itf->bNumEndpoints)
-  {
+  uint8_t found_ep = 0;
+  while (found_ep < desc_itf->bNumEndpoints) {
     // skip non-endpoint descriptors
-    while ( (TUSB_DESC_ENDPOINT != tu_desc_type(p_desc)) && (p_desc < desc_end) )
-    {
+    while ( (TUSB_DESC_ENDPOINT != tu_desc_type(p_desc)) && (p_desc < desc_end) ) {
       p_desc = tu_desc_next(p_desc);
     }
-
-    // Open endpoint pair with usbd helper
-    TU_ASSERT(usbd_open_edpt_pair(rhport, p_desc, desc_itf->bNumEndpoints, TUSB_XFER_BULK, &p_vendor->ep_out, &p_vendor->ep_in), 0);
-
-    p_desc += desc_itf->bNumEndpoints*sizeof(tusb_desc_endpoint_t);
-
-    // Prepare for incoming data
-    if ( p_vendor->ep_out )
-    {
-      _prep_out_transaction(p_vendor);
+    if (p_desc >= desc_end) {
+      break;
     }
 
-    if ( p_vendor->ep_in ) tud_vendor_n_write_flush((uint8_t)(p_vendor - _vendord_itf));
+    const tusb_desc_endpoint_t* desc_ep = (const tusb_desc_endpoint_t*) p_desc;
+    TU_ASSERT(usbd_edpt_open(rhport, desc_ep));
+    found_ep++;
+
+    if (tu_edpt_dir(desc_ep->bEndpointAddress) == TUSB_DIR_IN) {
+      tu_edpt_stream_open(&p_vendor->tx.stream, desc_ep);
+      tud_vendor_n_write_flush((uint8_t)(p_vendor - _vendord_itf));
+    } else {
+      tu_edpt_stream_open(&p_vendor->rx.stream, desc_ep);
+      TU_ASSERT(tu_edpt_stream_read_xfer(rhport, &p_vendor->rx.stream) > 0, 0); // prepare for incoming data
+    }
+
+    p_desc = tu_desc_next(p_desc);
   }
 
   return (uint16_t) ((uintptr_t) p_desc - (uintptr_t) desc_itf);
 }
 
-bool vendord_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes)
-{
+bool vendord_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes) {
   (void) result;
 
   uint8_t itf = 0;
   vendord_interface_t* p_itf = _vendord_itf;
 
-  for ( ; ; itf++, p_itf++)
-  {
-    if (itf >= TU_ARRAY_SIZE(_vendord_itf)) return false;
-
-    if ( ( ep_addr == p_itf->ep_out ) || ( ep_addr == p_itf->ep_in ) ) break;
+  for ( ; ; itf++, p_itf++) {
+    if (itf >= CFG_TUD_VENDOR) return false;
+    if ((ep_addr == p_itf->rx.stream.ep_addr) || (ep_addr == p_itf->tx.stream.ep_addr)) break;
   }
 
-  if ( ep_addr == p_itf->ep_out )
-  {
-    // Receive new data
-    tu_fifo_write_n(&p_itf->rx_ff, p_itf->epout_buf, (uint16_t) xferred_bytes);
+  if ( ep_addr == p_itf->rx.stream.ep_addr ) {
+    // Received new data: put into stream's fifo
+    tu_edpt_stream_read_xfer_complete(&p_itf->rx.stream, xferred_bytes);
 
     // Invoked callback if any
-    if (tud_vendor_rx_cb) tud_vendor_rx_cb(itf);
-
-    _prep_out_transaction(p_itf);
-  }
-  else if ( ep_addr == p_itf->ep_in )
-  {
-    if (tud_vendor_tx_cb) tud_vendor_tx_cb(itf, (uint16_t) xferred_bytes);
-    // Send complete, try to send more if possible
-    if ( 0 == tud_vendor_n_write_flush(itf) )
-    {
-      // If there is no data left, a ZLP should be sent if
-      // xferred_bytes is multiple of EP Packet size and not zero
-      if ( !tu_fifo_count(&p_itf->tx_ff) && xferred_bytes && (0 == (xferred_bytes & (BULK_PACKET_SIZE-1))) )
-      {
-        if ( usbd_edpt_claim(rhport, p_itf->ep_in) )
-        {
-          usbd_edpt_xfer(rhport, p_itf->ep_in, NULL, 0);
-        }
-      }
+    if (tud_vendor_rx_cb) {
+      tud_vendor_rx_cb(itf, p_itf->epout_buf, (uint16_t) xferred_bytes);
     }
+
+    tu_edpt_stream_read_xfer(rhport, &p_itf->rx.stream);
+  } else if ( ep_addr == p_itf->tx.stream.ep_addr ) {
+    // Send complete
+    if (tud_vendor_tx_cb) {
+      tud_vendor_tx_cb(itf, (uint16_t) xferred_bytes);
+    }
+
+    #if CFG_TUD_VENDOR_TX_BUFSIZE > 0
+    // try to send more if possible
+    if ( 0 == tu_edpt_stream_write_xfer(rhport, &p_itf->tx.stream) ) {
+      // If there is no data left, a ZLP should be sent if xferred_bytes is multiple of EP Packet size and not zero
+      tu_edpt_stream_write_zlp_if_needed(rhport, &p_itf->tx.stream, xferred_bytes);
+    }
+    #endif
   }
 
   return true;

--- a/src/class/vendor/vendor_device.h
+++ b/src/class/vendor/vendor_device.h
@@ -33,15 +33,24 @@
 #define CFG_TUD_VENDOR_EPSIZE     64
 #endif
 
+// RX FIFO can be disabled by setting this value to 0
+#ifndef CFG_TUD_VENDOR_RX_BUFSIZE
+#define CFG_TUD_VENDOR_RX_BUFSIZE    64
+#endif
+
+// TX FIFO can be disabled by setting this value to 0
+#ifndef CFG_TUD_VENDOR_TX_BUFSIZE
+#define CFG_TUD_VENDOR_TX_BUFSIZE    64
+#endif
+
 #ifdef __cplusplus
  extern "C" {
 #endif
 
 //--------------------------------------------------------------------+
-// Application API (Multiple Interfaces)
+// Application API (Multiple Interfaces) i.e CFG_TUD_VENDOR > 1
 //--------------------------------------------------------------------+
 bool     tud_vendor_n_mounted         (uint8_t itf);
-
 uint32_t tud_vendor_n_available       (uint8_t itf);
 uint32_t tud_vendor_n_read            (uint8_t itf, void* buffer, uint32_t bufsize);
 bool     tud_vendor_n_peek            (uint8_t itf, uint8_t* ui8);
@@ -51,23 +60,56 @@ uint32_t tud_vendor_n_write           (uint8_t itf, void const* buffer, uint32_t
 uint32_t tud_vendor_n_write_flush     (uint8_t itf);
 uint32_t tud_vendor_n_write_available (uint8_t itf);
 
-static inline uint32_t tud_vendor_n_write_str (uint8_t itf, char const* str);
+TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_vendor_n_write_str (uint8_t itf, char const* str);
 
 // backward compatible
 #define tud_vendor_n_flush(itf) tud_vendor_n_write_flush(itf)
 
 //--------------------------------------------------------------------+
-// Application API (Single Port)
+// Application API (Single Port) i.e CFG_TUD_VENDOR = 1
 //--------------------------------------------------------------------+
-static inline bool     tud_vendor_mounted         (void);
-static inline uint32_t tud_vendor_available       (void);
-static inline uint32_t tud_vendor_read            (void* buffer, uint32_t bufsize);
-static inline bool     tud_vendor_peek            (uint8_t* ui8);
-static inline void     tud_vendor_read_flush      (void);
-static inline uint32_t tud_vendor_write           (void const* buffer, uint32_t bufsize);
-static inline uint32_t tud_vendor_write_str       (char const* str);
-static inline uint32_t tud_vendor_write_available (void);
-static inline uint32_t tud_vendor_write_flush     (void);
+
+TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_vendor_n_write_str(uint8_t itf, char const* str) {
+ return tud_vendor_n_write(itf, str, strlen(str));
+}
+
+TU_ATTR_ALWAYS_INLINE static inline bool tud_vendor_mounted(void) {
+ return tud_vendor_n_mounted(0);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_vendor_available(void) {
+ return tud_vendor_n_available(0);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_vendor_read(void* buffer, uint32_t bufsize) {
+ return tud_vendor_n_read(0, buffer, bufsize);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline bool tud_vendor_peek(uint8_t* ui8) {
+ return tud_vendor_n_peek(0, ui8);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline void tud_vendor_read_flush(void) {
+ tud_vendor_n_read_flush(0);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_vendor_write(void const* buffer, uint32_t bufsize) {
+ return tud_vendor_n_write(0, buffer, bufsize);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_vendor_write_str(char const* str) {
+ return tud_vendor_n_write_str(0, str);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_vendor_write_flush(void) {
+ return tud_vendor_n_write_flush(0);
+}
+
+#if CFG_TUD_VENDOR_TX_BUFSIZE > 0
+TU_ATTR_ALWAYS_INLINE static inline uint32_t tud_vendor_write_available(void) {
+ return tud_vendor_n_write_available(0);
+}
+#endif
 
 // backward compatible
 #define tud_vendor_flush() tud_vendor_write_flush()
@@ -77,7 +119,7 @@ static inline uint32_t tud_vendor_write_flush     (void);
 //--------------------------------------------------------------------+
 
 // Invoked when received new data
-TU_ATTR_WEAK void tud_vendor_rx_cb(uint8_t itf);
+TU_ATTR_WEAK void tud_vendor_rx_cb(uint8_t itf, uint8_t const* buffer, uint16_t bufsize);
 // Invoked when last rx transfer finished
 TU_ATTR_WEAK void tud_vendor_tx_cb(uint8_t itf, uint32_t sent_bytes);
 
@@ -85,55 +127,6 @@ TU_ATTR_WEAK void tud_vendor_tx_cb(uint8_t itf, uint32_t sent_bytes);
 // Inline Functions
 //--------------------------------------------------------------------+
 
-static inline uint32_t tud_vendor_n_write_str (uint8_t itf, char const* str)
-{
-  return tud_vendor_n_write(itf, str, strlen(str));
-}
-
-static inline bool tud_vendor_mounted (void)
-{
-  return tud_vendor_n_mounted(0);
-}
-
-static inline uint32_t tud_vendor_available (void)
-{
-  return tud_vendor_n_available(0);
-}
-
-static inline uint32_t tud_vendor_read (void* buffer, uint32_t bufsize)
-{
-  return tud_vendor_n_read(0, buffer, bufsize);
-}
-
-static inline bool tud_vendor_peek (uint8_t* ui8)
-{
-  return tud_vendor_n_peek(0, ui8);
-}
-
-static inline void tud_vendor_read_flush(void)
-{
-    tud_vendor_n_read_flush(0);
-}
-
-static inline uint32_t tud_vendor_write (void const* buffer, uint32_t bufsize)
-{
-  return tud_vendor_n_write(0, buffer, bufsize);
-}
-
-static inline uint32_t tud_vendor_write_flush (void)
-{
-  return tud_vendor_n_write_flush(0);
-}
-
-static inline uint32_t tud_vendor_write_str (char const* str)
-{
-  return tud_vendor_n_write_str(0, str);
-}
-
-static inline uint32_t tud_vendor_write_available (void)
-{
-  return tud_vendor_n_write_available(0);
-}
 
 //--------------------------------------------------------------------+
 // Internal Class Driver API

--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -403,7 +403,7 @@ static inline void const *_find_desc_format(void const *beg, void const *end, ui
     if ((fmt == VIDEO_CS_ITF_VS_FORMAT_UNCOMPRESSED ||
          fmt == VIDEO_CS_ITF_VS_FORMAT_MJPEG ||
          fmt == VIDEO_CS_ITF_VS_FORMAT_DV ||
-         fmt == VIDEO_CS_ITF_VS_FRAME_FRAME_BASED) &&
+         fmt == VIDEO_CS_ITF_VS_FORMAT_FRAME_BASED) &&
         fmtnum == p[3]) {
       return cur;
     }
@@ -712,7 +712,7 @@ static bool _open_vc_itf(uint8_t rhport, videod_interface_t *self, uint_fast8_t 
 
   /* The first descriptor is a video control interface descriptor. */
   uint8_t const *cur = _find_desc_itf(beg, end, _desc_itfnum(beg), altnum);
-  TU_LOG_DRV("    cur %d\r\n", cur - beg);
+  TU_LOG_DRV("    cur %" PRId32 "\r\n", (int32_t) (cur - beg));
   TU_VERIFY(cur < end);
 
   tusb_desc_vc_itf_t const *vc = (tusb_desc_vc_itf_t const *)cur;

--- a/src/common/tusb_common.h
+++ b/src/common/tusb_common.h
@@ -79,7 +79,7 @@
 
 //--------------------------------------------------------------------+
 // Optional API implemented by application if needed
-// TODO move to a more ovious place/file
+// TODO move to a more obvious place/file
 //--------------------------------------------------------------------+
 
 // flush data cache

--- a/src/common/tusb_compiler.h
+++ b/src/common/tusb_compiler.h
@@ -119,6 +119,14 @@
 #define _TU_ARGS_APPLY_8(_X, _s, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8) _X(_a1) _s _TU_ARGS_APPLY_7(_X, _s, _a2, _a3, _a4, _a5, _a6, _a7, _a8)
 
 //--------------------------------------------------------------------+
+// Macro for function default arguments
+//--------------------------------------------------------------------+
+#define TU_GET_3RD_ARG(arg1, arg2, arg3, ...)        arg3
+
+// function expand with number of arguments
+#define TU_FUNC_OPTIONAL_ARG(func, ...)   TU_XSTRCAT(func##_arg, TU_ARGS_NUM(__VA_ARGS__))(__VA_ARGS__)
+
+//--------------------------------------------------------------------+
 // Compiler porting with Attribute and Endian
 //--------------------------------------------------------------------+
 

--- a/src/common/tusb_fifo.h
+++ b/src/common/tusb_fifo.h
@@ -154,14 +154,14 @@ void tu_fifo_config_mutex(tu_fifo_t *f, osal_mutex_t wr_mutex, osal_mutex_t rd_m
 #define tu_fifo_config_mutex(_f, _wr_mutex, _rd_mutex)
 #endif
 
-bool     tu_fifo_write                  (tu_fifo_t* f, void const * p_data);
-uint16_t tu_fifo_write_n                (tu_fifo_t* f, void const * p_data, uint16_t n);
+bool     tu_fifo_write                  (tu_fifo_t* f, void const * data);
+uint16_t tu_fifo_write_n                (tu_fifo_t* f, void const * data, uint16_t n);
 #ifdef TUP_MEM_CONST_ADDR
 uint16_t tu_fifo_write_n_const_addr_full_words    (tu_fifo_t* f, const void * data, uint16_t n);
 #endif
 
-bool     tu_fifo_read                   (tu_fifo_t* f, void * p_buffer);
-uint16_t tu_fifo_read_n                 (tu_fifo_t* f, void * p_buffer, uint16_t n);
+bool     tu_fifo_read                   (tu_fifo_t* f, void * buffer);
+uint16_t tu_fifo_read_n                 (tu_fifo_t* f, void * buffer, uint16_t n);
 #ifdef TUP_MEM_CONST_ADDR
 uint16_t tu_fifo_read_n_const_addr_full_words     (tu_fifo_t* f, void * buffer, uint16_t n);
 #endif

--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -293,6 +293,11 @@
   #define TUP_USBIP_FSDEV_STM32
   #define TUP_DCD_ENDPOINT_MAX    8
 
+#elif TU_CHECK_MCU(OPT_MCU_STM32U0)
+  #define TUP_USBIP_FSDEV
+  #define TUP_USBIP_FSDEV_STM32
+  #define TUP_DCD_ENDPOINT_MAX    8
+
 //--------------------------------------------------------------------+
 // Sony
 //--------------------------------------------------------------------+
@@ -337,7 +342,13 @@
 #elif TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3)
   #define TUP_USBIP_DWC2
   #define TUP_USBIP_DWC2_ESP32
-  #define TUP_DCD_ENDPOINT_MAX    6
+  #define TUP_DCD_ENDPOINT_MAX    7 // only 5 TX FIFO for endpoint IN
+
+#elif TU_CHECK_MCU(OPT_MCU_ESP32P4)
+  #define TUP_USBIP_DWC2
+  #define TUP_USBIP_DWC2_ESP32
+  #define TUP_RHPORT_HIGHSPEED    1  // port0 FS, port1 HS
+  #define TUP_DCD_ENDPOINT_MAX    16 // FS 7 ep, HS 16 ep
 
 #elif TU_CHECK_MCU(OPT_MCU_ESP32, OPT_MCU_ESP32C2, OPT_MCU_ESP32C3, OPT_MCU_ESP32C6, OPT_MCU_ESP32H2)
   #if (CFG_TUD_ENABLED || !(defined(CFG_TUH_MAX3421) && CFG_TUH_MAX3421))
@@ -524,7 +535,7 @@
   #define TUP_DCD_EDPT_ISO_ALLOC
 #endif
 
-#if defined(TUP_USBIP_DWC2)
+#if defined(TUP_USBIP_DWC2) // && CFG_TUD_DWC2_DMA == 0
   #define TUP_MEM_CONST_ADDR
 #endif
 

--- a/src/common/tusb_types.h
+++ b/src/common/tusb_types.h
@@ -39,11 +39,18 @@
 /* CONSTANTS
  *------------------------------------------------------------------*/
 
+typedef enum {
+  TUSB_ROLE_INVALID = 0,
+  TUSB_ROLE_DEVICE,
+  TUSB_ROLE_HOST,
+} tusb_role_t;
+
 /// defined base on EHCI specs value for Endpoint Speed
 typedef enum {
   TUSB_SPEED_FULL = 0,
   TUSB_SPEED_LOW  = 1,
   TUSB_SPEED_HIGH = 2,
+  TUSB_SPEED_AUTO = 0xaa,
   TUSB_SPEED_INVALID = 0xff,
 } tusb_speed_t;
 
@@ -266,6 +273,14 @@ enum {
 enum {
   TUSB_INDEX_INVALID_8 = 0xFFu
 };
+
+//--------------------------------------------------------------------+
+//
+//--------------------------------------------------------------------+
+typedef struct {
+  tusb_role_t role;
+  tusb_speed_t speed;
+} tusb_rhport_init_t;
 
 //--------------------------------------------------------------------+
 // USB Descriptors

--- a/src/common/tusb_verify.h
+++ b/src/common/tusb_verify.h
@@ -93,9 +93,6 @@
   #define TU_BREAKPOINT() do {} while (0)
 #endif
 
-// Helper to implement optional parameter for TU_VERIFY Macro family
-#define _GET_3RD_ARG(arg1, arg2, arg3, ...)        arg3
-
 /*------------------------------------------------------------------*/
 /* TU_VERIFY
  * - TU_VERIFY_1ARGS : return false if failed
@@ -109,7 +106,7 @@
 #define TU_VERIFY_1ARGS(_cond)         TU_VERIFY_DEFINE(_cond, false)
 #define TU_VERIFY_2ARGS(_cond, _ret)   TU_VERIFY_DEFINE(_cond, _ret)
 
-#define TU_VERIFY(...)                 _GET_3RD_ARG(__VA_ARGS__, TU_VERIFY_2ARGS, TU_VERIFY_1ARGS, _dummy)(__VA_ARGS__)
+#define TU_VERIFY(...)                 TU_GET_3RD_ARG(__VA_ARGS__, TU_VERIFY_2ARGS, TU_VERIFY_1ARGS, _dummy)(__VA_ARGS__)
 
 /*------------------------------------------------------------------*/
 /* ASSERT
@@ -126,7 +123,7 @@
 #define TU_ASSERT_2ARGS(_cond, _ret)   TU_ASSERT_DEFINE(_cond, _ret)
 
 #ifndef TU_ASSERT
-#define TU_ASSERT(...)                 _GET_3RD_ARG(__VA_ARGS__, TU_ASSERT_2ARGS, TU_ASSERT_1ARGS, _dummy)(__VA_ARGS__)
+#define TU_ASSERT(...)                 TU_GET_3RD_ARG(__VA_ARGS__, TU_ASSERT_2ARGS, TU_ASSERT_1ARGS, _dummy)(__VA_ARGS__)
 #endif
 
 #ifdef __cplusplus

--- a/src/device/dcd.h
+++ b/src/device/dcd.h
@@ -108,7 +108,7 @@ void dcd_dcache_clean_invalidate(void const* addr, uint32_t data_size) TU_ATTR_W
 //--------------------------------------------------------------------+
 
 // Initialize controller to device mode
-void dcd_init(uint8_t rhport);
+bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init);
 
 // Deinitialize controller, unset device mode.
 bool dcd_deinit(uint8_t rhport);
@@ -157,10 +157,6 @@ bool dcd_edpt_open            (uint8_t rhport, tusb_desc_endpoint_t const * desc
 // required for multiple configuration support.
 void dcd_edpt_close_all       (uint8_t rhport);
 
-// Close an endpoint.
-// Since it is weak, caller must TU_ASSERT this function's existence before calling it.
-void dcd_edpt_close           (uint8_t rhport, uint8_t ep_addr) TU_ATTR_WEAK;
-
 // Submit a transfer, When complete dcd_event_xfer_complete() is invoked to notify the stack
 bool dcd_edpt_xfer            (uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes);
 
@@ -175,12 +171,19 @@ void dcd_edpt_stall           (uint8_t rhport, uint8_t ep_addr);
 // This API never calls with control endpoints, since it is auto cleared when receiving setup packet
 void dcd_edpt_clear_stall     (uint8_t rhport, uint8_t ep_addr);
 
+#ifdef TUP_DCD_EDPT_ISO_ALLOC
 // Allocate packet buffer used by ISO endpoints
 // Some MCU need manual packet buffer allocation, we allocate the largest size to avoid clustering
-TU_ATTR_WEAK bool dcd_edpt_iso_alloc(uint8_t rhport, uint8_t ep_addr, uint16_t largest_packet_size);
+bool dcd_edpt_iso_alloc(uint8_t rhport, uint8_t ep_addr, uint16_t largest_packet_size);
 
 // Configure and enable an ISO endpoint according to descriptor
-TU_ATTR_WEAK bool dcd_edpt_iso_activate(uint8_t rhport, tusb_desc_endpoint_t const * desc_ep);
+bool dcd_edpt_iso_activate(uint8_t rhport, tusb_desc_endpoint_t const * desc_ep);
+
+#else
+// Close an endpoint.
+void dcd_edpt_close(uint8_t rhport, uint8_t ep_addr);
+
+#endif
 
 //--------------------------------------------------------------------+
 // Event API (implemented by stack)
@@ -191,38 +194,45 @@ extern void dcd_event_handler(dcd_event_t const * event, bool in_isr);
 
 // helper to send bus signal event
 TU_ATTR_ALWAYS_INLINE static inline void dcd_event_bus_signal (uint8_t rhport, dcd_eventid_t eid, bool in_isr) {
-  dcd_event_t event = { .rhport = rhport, .event_id = eid };
+  dcd_event_t event;
+  event.rhport = rhport;
+  event.event_id = eid;
   dcd_event_handler(&event, in_isr);
 }
 
 // helper to send bus reset event
 TU_ATTR_ALWAYS_INLINE static inline  void dcd_event_bus_reset (uint8_t rhport, tusb_speed_t speed, bool in_isr) {
-  dcd_event_t event = { .rhport = rhport, .event_id = DCD_EVENT_BUS_RESET };
+  dcd_event_t event;
+  event.rhport = rhport;
+  event.event_id = DCD_EVENT_BUS_RESET;
   event.bus_reset.speed = speed;
   dcd_event_handler(&event, in_isr);
 }
 
 // helper to send setup received
 TU_ATTR_ALWAYS_INLINE static inline void dcd_event_setup_received(uint8_t rhport, uint8_t const * setup, bool in_isr) {
-  dcd_event_t event = { .rhport = rhport, .event_id = DCD_EVENT_SETUP_RECEIVED };
+  dcd_event_t event;
+  event.rhport = rhport;
+  event.event_id = DCD_EVENT_SETUP_RECEIVED;
   memcpy(&event.setup_received, setup, sizeof(tusb_control_request_t));
-
   dcd_event_handler(&event, in_isr);
 }
 
 // helper to send transfer complete event
 TU_ATTR_ALWAYS_INLINE static inline void dcd_event_xfer_complete (uint8_t rhport, uint8_t ep_addr, uint32_t xferred_bytes, uint8_t result, bool in_isr) {
-  dcd_event_t event = { .rhport = rhport, .event_id = DCD_EVENT_XFER_COMPLETE };
-
+  dcd_event_t event;
+  event.rhport = rhport;
+  event.event_id = DCD_EVENT_XFER_COMPLETE;
   event.xfer_complete.ep_addr = ep_addr;
   event.xfer_complete.len     = xferred_bytes;
   event.xfer_complete.result  = result;
-
   dcd_event_handler(&event, in_isr);
 }
 
 TU_ATTR_ALWAYS_INLINE static inline void dcd_event_sof(uint8_t rhport, uint32_t frame_count, bool in_isr) {
-  dcd_event_t event = { .rhport = rhport, .event_id = DCD_EVENT_SOF };
+  dcd_event_t event;
+  event.rhport = rhport;
+  event.event_id = DCD_EVENT_SOF;
   event.sof.frame_count = frame_count;
   dcd_event_handler(&event, in_isr);
 }

--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -453,11 +453,14 @@ bool tud_inited(void) {
   return _usbd_rhport != RHPORT_INVALID;
 }
 
-bool tud_init(uint8_t rhport) {
-  // skip if already initialized
-  if (tud_inited()) return true;
+bool tud_rhport_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
+  if (tud_inited()) {
+    return true; // skip if already initialized
+  }
+  TU_ASSERT(rh_init);
 
-  TU_LOG_USBD("USBD init on controller %u, Highspeed = %u\r\n", rhport, TUD_OPT_HIGH_SPEED);
+  TU_LOG_USBD("USBD init on controller %u, speed = %s\r\n", rhport,
+    rh_init->speed == TUSB_SPEED_HIGH ? "High" : "Full");
   TU_LOG_INT(CFG_TUD_LOG_LEVEL, sizeof(usbd_device_t));
   TU_LOG_INT(CFG_TUD_LOG_LEVEL, sizeof(dcd_event_t));
   TU_LOG_INT(CFG_TUD_LOG_LEVEL, sizeof(tu_fifo_t));
@@ -492,15 +495,16 @@ bool tud_init(uint8_t rhport) {
   _usbd_rhport = rhport;
 
   // Init device controller driver
-  dcd_init(rhport);
+  TU_ASSERT(dcd_init(rhport, rh_init));
   dcd_int_enable(rhport);
 
   return true;
 }
 
 bool tud_deinit(uint8_t rhport) {
-  // skip if not initialized
-  if (!tud_inited()) return true;
+  if (!tud_inited()) {
+    return true; // skip if not initialized
+  }
 
   TU_LOG_USBD("USBD deinit on controller %u\r\n", rhport);
 
@@ -562,7 +566,7 @@ bool tud_task_event_ready(void) {
  *
     int main(void) {
       application_init();
-      tusb_init();
+      tusb_init(0, TUSB_ROLE_DEVICE);
 
       while(1) { // the mainloop
         application_code();
@@ -1427,9 +1431,12 @@ bool usbd_edpt_stalled(uint8_t rhport, uint8_t ep_addr) {
  * In progress transfers on this EP may be delivered after this call.
  */
 void usbd_edpt_close(uint8_t rhport, uint8_t ep_addr) {
+#ifdef TUP_DCD_EDPT_ISO_ALLOC
+  (void) rhport; (void) ep_addr;
+  // ISO alloc/activate Should be used instead
+#else
   rhport = _usbd_rhport;
 
-  TU_ASSERT(dcd_edpt_close, /**/);
   TU_LOG_USBD("  CLOSING Endpoint: 0x%02X\r\n", ep_addr);
 
   uint8_t const epnum = tu_edpt_number(ep_addr);
@@ -1439,6 +1446,7 @@ void usbd_edpt_close(uint8_t rhport, uint8_t ep_addr) {
   _usbd_dev.ep_status[epnum][dir].stalled = 0;
   _usbd_dev.ep_status[epnum][dir].busy = 0;
   _usbd_dev.ep_status[epnum][dir].claimed = 0;
+#endif
 
   return;
 }
@@ -1461,21 +1469,24 @@ void usbd_sof_enable(uint8_t rhport, sof_consumer_t consumer, bool en) {
 }
 
 bool usbd_edpt_iso_alloc(uint8_t rhport, uint8_t ep_addr, uint16_t largest_packet_size) {
+#ifdef TUP_DCD_EDPT_ISO_ALLOC
   rhport = _usbd_rhport;
 
-  TU_ASSERT(dcd_edpt_iso_alloc);
   TU_ASSERT(tu_edpt_number(ep_addr) < CFG_TUD_ENDPPOINT_MAX);
-
   return dcd_edpt_iso_alloc(rhport, ep_addr, largest_packet_size);
+#else
+  (void) rhport; (void) ep_addr; (void) largest_packet_size;
+  return false;
+#endif
 }
 
 bool usbd_edpt_iso_activate(uint8_t rhport, tusb_desc_endpoint_t const* desc_ep) {
+#ifdef TUP_DCD_EDPT_ISO_ALLOC
   rhport = _usbd_rhport;
 
   uint8_t const epnum = tu_edpt_number(desc_ep->bEndpointAddress);
   uint8_t const dir = tu_edpt_dir(desc_ep->bEndpointAddress);
 
-  TU_ASSERT(dcd_edpt_iso_activate);
   TU_ASSERT(epnum < CFG_TUD_ENDPPOINT_MAX);
   TU_ASSERT(tu_edpt_validate(desc_ep, (tusb_speed_t) _usbd_dev.speed));
 
@@ -1483,6 +1494,10 @@ bool usbd_edpt_iso_activate(uint8_t rhport, tusb_desc_endpoint_t const* desc_ep)
   _usbd_dev.ep_status[epnum][dir].busy = 0;
   _usbd_dev.ep_status[epnum][dir].claimed = 0;
   return dcd_edpt_iso_activate(rhport, desc_ep);
+#else
+  (void) rhport; (void) desc_ep;
+  return false;
+#endif
 }
 
 #endif

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -37,8 +37,20 @@ extern "C" {
 // Application API
 //--------------------------------------------------------------------+
 
+// New API to replace tud_init() to init device stack on specific roothub port
+bool tud_rhport_init(uint8_t rhport, const tusb_rhport_init_t* rh_init);
+
 // Init device stack on roothub port
-bool tud_init (uint8_t rhport);
+#if TUSB_VERSION_NUMBER > 2000  // 0.20.0
+TU_ATTR_DEPRECATED("Please use tusb_init(rhport, rh_init) instead")
+#endif
+TU_ATTR_ALWAYS_INLINE static inline bool tud_init (uint8_t rhport) {
+  const tusb_rhport_init_t rh_init = {
+    .role = TUSB_ROLE_DEVICE,
+    .speed = TUD_OPT_HIGH_SPEED ? TUSB_SPEED_HIGH : TUSB_SPEED_FULL
+  };
+  return tud_rhport_init(rhport, &rh_init);
+}
 
 // Deinit device stack on roothub port
 bool tud_deinit(uint8_t rhport);

--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -142,7 +142,7 @@ bool tud_control_xfer(uint8_t rhport, tusb_control_request_t const* request, voi
 void usbd_control_reset(void);
 void usbd_control_set_request(tusb_control_request_t const* request);
 void usbd_control_set_complete_callback(usbd_control_xfer_cb_t fp);
-bool usbd_control_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t xferred_bytes);
+bool usbd_control_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result, uint32_t xferred_bytes);
 
 void usbd_control_reset(void) {
   tu_varclr(&_ctrl_xfer);

--- a/src/device/usbd_pvt.h
+++ b/src/device/usbd_pvt.h
@@ -28,6 +28,7 @@
 
 #include "osal/osal.h"
 #include "common/tusb_fifo.h"
+#include "common/tusb_private.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/src/host/hcd.h
+++ b/src/host/hcd.h
@@ -53,26 +53,21 @@
 //--------------------------------------------------------------------+
 // MACRO CONSTANT TYPEDEF
 //--------------------------------------------------------------------+
-typedef enum
-{
+typedef enum {
   HCD_EVENT_DEVICE_ATTACH,
   HCD_EVENT_DEVICE_REMOVE,
   HCD_EVENT_XFER_COMPLETE,
 
-  // Not an HCD event, just a convenient way to defer ISR function
-  USBH_EVENT_FUNC_CALL,
-
+  USBH_EVENT_FUNC_CALL, // Not an HCD event
   HCD_EVENT_COUNT
 } hcd_eventid_t;
 
-typedef struct
-{
+typedef struct {
   uint8_t rhport;
   uint8_t event_id;
   uint8_t dev_addr;
 
-  union
-  {
+  union {
     // Attach, Remove
     struct {
       uint8_t hub_addr;
@@ -93,11 +88,9 @@ typedef struct
       void* param;
     }func_call;
   };
-
 } hcd_event_t;
 
-typedef struct
-{
+typedef struct {
   uint8_t rhport;
   uint8_t hub_addr;
   uint8_t hub_port;
@@ -128,7 +121,7 @@ bool hcd_dcache_clean_invalidate(void const* addr, uint32_t data_size) TU_ATTR_W
 bool hcd_configure(uint8_t rhport, uint32_t cfg_id, const void* cfg_param);
 
 // Initialize controller to host mode
-bool hcd_init(uint8_t rhport);
+bool hcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init);
 
 // De-initialize controller
 bool hcd_deinit(uint8_t rhport);

--- a/src/host/usbh.c
+++ b/src/host/usbh.c
@@ -383,11 +383,13 @@ bool tuh_inited(void) {
   return _usbh_controller != TUSB_INDEX_INVALID_8;
 }
 
-bool tuh_init(uint8_t rhport) {
-  // skip if already initialized
-  if (tuh_rhport_is_active(rhport)) return true;
+bool tuh_rhport_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
+  if (tuh_rhport_is_active(rhport)) {
+    return true; // skip if already initialized
+  }
 
-  TU_LOG_USBH("USBH init on controller %u\r\n", rhport);
+  TU_LOG_USBH("USBH init on controller %u, speed = %s\r\n", rhport,
+    rh_init->speed == TUSB_SPEED_HIGH ? "High" : "Full");
 
   // Init host stack if not already
   if (!tuh_inited()) {
@@ -433,8 +435,8 @@ bool tuh_init(uint8_t rhport) {
   }
 
   // Init host controller
-  _usbh_controller = rhport;;
-  TU_ASSERT(hcd_init(rhport));
+  _usbh_controller = rhport;
+  TU_ASSERT(hcd_init(rhport, rh_init));
   hcd_int_enable(rhport);
 
   return true;
@@ -490,7 +492,7 @@ bool tuh_task_event_ready(void) {
     int main(void)
     {
       application_init();
-      tusb_init();
+      tusb_init(0, TUSB_ROLE_HOST);
 
       while(1) // the mainloop
       {

--- a/src/host/usbh.h
+++ b/src/host/usbh.h
@@ -120,8 +120,20 @@ void tuh_event_hook_cb(uint8_t rhport, uint32_t eventid, bool in_isr);
 // - cfg_param: configure data, structure depends on the ID
 bool tuh_configure(uint8_t rhport, uint32_t cfg_id, const void* cfg_param);
 
+// New API to replace tuh_init() to init host stack on specific roothub port
+bool tuh_rhport_init(uint8_t rhport, const tusb_rhport_init_t* rh_init);
+
 // Init host stack
-bool tuh_init(uint8_t rhport);
+#if TUSB_VERSION_NUMBER > 2000  // 0.20.0
+TU_ATTR_DEPRECATED("Please use tusb_init(rhport, rh_init) instead")
+#endif
+TU_ATTR_ALWAYS_INLINE static inline bool tuh_init(uint8_t rhport) {
+  const tusb_rhport_init_t rh_init = {
+    .role = TUSB_ROLE_HOST,
+    .speed = TUH_OPT_HIGH_SPEED ? TUSB_SPEED_HIGH : TUSB_SPEED_FULL,
+  };
+  return tuh_rhport_init(rhport, &rh_init);
+}
 
 // Deinit host stack on rhport
 bool tuh_deinit(uint8_t rhport);
@@ -149,12 +161,10 @@ extern void hcd_int_handler(uint8_t rhport, bool in_isr);
 #endif
 
 // Interrupt handler alias to HCD with in_isr as optional parameter
-// - tuh_int_handler(rhport) --> hcd_int_handler(rhport, true)
-// - tuh_int_handler(rhport, in_isr) --> hcd_int_handler(rhport, in_isr)
-// Note: this is similar to TU_VERIFY(), _GET_3RD_ARG() is defined in tusb_verify.h
-#define _tuh_int_handler_1arg(_rhport)            hcd_int_handler(_rhport, true)
-#define _tuh_int_hanlder_2arg(_rhport, _in_isr)   hcd_int_handler(_rhport, _in_isr)
-#define tuh_int_handler(...)   _GET_3RD_ARG(__VA_ARGS__, _tuh_int_hanlder_2arg, _tuh_int_handler_1arg, _dummy)(__VA_ARGS__)
+#define _tuh_int_handler_arg0()                   TU_VERIFY_STATIC(false, "tuh_int_handler() must have 1 or 2 arguments")
+#define _tuh_int_handler_arg1(_rhport)            hcd_int_handler(_rhport, true)
+#define _tuh_int_handler_arg2(_rhport, _in_isr)   hcd_int_handler(_rhport, _in_isr)
+#define tuh_int_handler(...)   TU_FUNC_OPTIONAL_ARG(_tuh_int_handler, __VA_ARGS__)
 
 // Check if roothub port is initialized and active as a host
 bool tuh_rhport_is_active(uint8_t rhport);

--- a/src/portable/analog/max3421/hcd_max3421.c
+++ b/src/portable/analog/max3421/hcd_max3421.c
@@ -499,8 +499,8 @@ bool hcd_configure(uint8_t rhport, uint32_t cfg_id, const void* cfg_param) {
 }
 
 // Initialize controller to host mode
-bool hcd_init(uint8_t rhport) {
-  (void) rhport;
+bool hcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
+  (void) rh_init;
 
   tuh_max3421_int_api(rhport, false);
 

--- a/src/portable/analog/max3421/hcd_max3421.c
+++ b/src/portable/analog/max3421/hcd_max3421.c
@@ -238,7 +238,13 @@ typedef struct {
     uint8_t hxfr;
   }sndfifo_owner;
 
+#if CFG_TUSB_MCU == OPT_MCU_RP2040
+  // currently has undefined reference to `__atomic_test_and_set' with rp2040 on Arduino with gcc 14.2
+  // temporarily use native semaphore instead. TODO rework osal semaphore/mutex later on
+  semaphore_t busy; // busy transferring
+#else
   atomic_flag busy; // busy transferring
+#endif
 
 #if OSAL_MUTEX_REQUIRED
   OSAL_MUTEX_DEF(spi_mutexdef);
@@ -256,6 +262,25 @@ static tuh_configure_max3421_t _tuh_cfg = {
     .cpuctl = 0, // default: INT pulse width = 10.6 us
     .pinctl = 0, // default: negative edge interrupt
 };
+
+#if CFG_TUSB_MCU == OPT_MCU_RP2040
+TU_ATTR_ALWAYS_INLINE static inline bool usb_xfer_test_and_set(void) {
+  return !sem_try_acquire(&_hcd_data.busy);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline void usb_xfer_clear(void) {
+  sem_release(&_hcd_data.busy);
+}
+
+#else
+TU_ATTR_ALWAYS_INLINE static inline bool usb_xfer_test_and_set(void) {
+  return atomic_flag_test_and_set(&_hcd_data.busy);
+}
+
+TU_ATTR_ALWAYS_INLINE static inline void usb_xfer_clear(void) {
+  atomic_flag_clear(&_hcd_data.busy);
+}
+#endif
 
 //--------------------------------------------------------------------+
 // API: SPI transfer with MAX3421E
@@ -511,6 +536,10 @@ bool hcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
   tu_memclr(&_hcd_data, sizeof(_hcd_data));
   _hcd_data.peraddr = 0xff; // invalid
 
+#if CFG_TUSB_MCU == OPT_MCU_RP2040
+  sem_init(&_hcd_data.busy, 1, 1);
+#endif
+
 #if OSAL_MUTEX_REQUIRED
   _hcd_data.spi_mutex = osal_mutex_create(&_hcd_data.spi_mutexdef);
 #endif
@@ -567,6 +596,10 @@ bool hcd_deinit(uint8_t rhport) {
   osal_mutex_delete(_hcd_data.spi_mutex);
   _hcd_data.spi_mutex = NULL;
   #endif
+
+#if CFG_TUSB_MCU == OPT_MCU_RP2040
+  sem_reset(&_hcd_data.busy, 1);
+#endif
 
   return true;
 }
@@ -754,7 +787,7 @@ bool hcd_edpt_xfer(uint8_t rhport, uint8_t daddr, uint8_t ep_addr, uint8_t * buf
   ep->state = EP_STATE_ATTEMPT_1;
 
   // carry out transfer if not busy
-  if (!atomic_flag_test_and_set(&_hcd_data.busy)) {
+  if (!usb_xfer_test_and_set()) {
     xact_generic(rhport, ep, true, false);
   }
 
@@ -791,7 +824,7 @@ bool hcd_setup_send(uint8_t rhport, uint8_t daddr, uint8_t const setup_packet[8]
   ep->state = EP_STATE_ATTEMPT_1;
 
   // carry out transfer if not busy
-  if (!atomic_flag_test_and_set(&_hcd_data.busy)) {
+  if (!usb_xfer_test_and_set()) {
     xact_setup(rhport, ep, false);
   }
 
@@ -876,7 +909,7 @@ static void xfer_complete_isr(uint8_t rhport, max3421_ep_t *ep, xfer_result_t re
     xact_generic(rhport, next_ep, true, in_isr);
   }else {
     // no more pending
-    atomic_flag_clear(&_hcd_data.busy);
+    usb_xfer_clear();
   }
 }
 
@@ -915,7 +948,7 @@ static void handle_xfer_done(uint8_t rhport, bool in_isr) {
         xact_generic(rhport, next_ep, true, in_isr);
       } else {
         // no more pending in this frame -> clear busy
-        atomic_flag_clear(&_hcd_data.busy);
+        usb_xfer_clear();
       }
       return;
 
@@ -1026,7 +1059,7 @@ void hcd_int_handler(uint8_t rhport, bool in_isr) {
     }
 
     // start usb transfer if not busy
-    if (ep_retry != NULL && !atomic_flag_test_and_set(&_hcd_data.busy)) {
+    if (ep_retry != NULL && !usb_xfer_test_and_set()) {
       xact_generic(rhport, ep_retry, true, in_isr);
     }
   }

--- a/src/portable/microchip/samd/dcd_samd.c
+++ b/src/portable/microchip/samd/dcd_samd.c
@@ -78,9 +78,9 @@ static void bus_reset(void)
 /*------------------------------------------------------------------*/
 /* Controller API
  *------------------------------------------------------------------*/
-void dcd_init (uint8_t rhport)
-{
+bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
   (void) rhport;
+  (void) rh_init;
 
   // Reset to get in a clean state.
   USB->DEVICE.CTRLA.bit.SWRST = true;
@@ -102,6 +102,8 @@ void dcd_init (uint8_t rhport)
 
   USB->DEVICE.INTFLAG.reg |= USB->DEVICE.INTFLAG.reg; // clear pending
   USB->DEVICE.INTENSET.reg = /* USB_DEVICE_INTENSET_SOF | */ USB_DEVICE_INTENSET_EORST;
+
+  return true;
 }
 
 #if CFG_TUSB_MCU == OPT_MCU_SAMD51 || CFG_TUSB_MCU == OPT_MCU_SAME5X

--- a/src/portable/nordic/nrf5x/dcd_nrf5x.c
+++ b/src/portable/nordic/nrf5x/dcd_nrf5x.c
@@ -230,9 +230,11 @@ static void xact_in_dma(uint8_t epnum) {
 //--------------------------------------------------------------------+
 // Controller API
 //--------------------------------------------------------------------+
-void dcd_init(uint8_t rhport) {
-  TU_LOG2("dcd init\r\n");
+bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
   (void) rhport;
+  (void) rh_init;
+  TU_LOG2("dcd init\r\n");
+  return true;
 }
 
 void dcd_int_enable(uint8_t rhport) {

--- a/src/portable/raspberrypi/pio_usb/dcd_pio_usb.c
+++ b/src/portable/raspberrypi/pio_usb/dcd_pio_usb.c
@@ -50,12 +50,13 @@ static usb_descriptor_buffers_t desc;
  *------------------------------------------------------------------*/
 
 // Initialize controller to device mode
-void dcd_init (uint8_t rhport)
-{
+bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
   (void) rhport;
-
+  (void) rh_init;
   static pio_usb_configuration_t config = PIO_USB_DEFAULT_CONFIG;
   usb_device = pio_usb_device_init(&config, &desc);
+
+  return true;
 }
 
 // Enable device interrupt

--- a/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
+++ b/src/portable/raspberrypi/pio_usb/hcd_pio_usb.c
@@ -55,8 +55,9 @@ bool hcd_configure(uint8_t rhport, uint32_t cfg_id, const void *cfg_param) {
   return true;
 }
 
-bool hcd_init(uint8_t rhport) {
+bool hcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
   (void) rhport;
+  (void) rh_init;
 
   // To run USB SOF interrupt in core1, call this init in core1
   pio_usb_host_init(&pio_host_cfg);

--- a/src/portable/raspberrypi/rp2040/dcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/dcd_rp2040.c
@@ -369,7 +369,8 @@ static void __tusb_irq_path_func(dcd_rp2040_irq)(void) {
 #define PICO_SHARED_IRQ_HANDLER_HIGHEST_ORDER_PRIORITY 0xff
 #endif
 
-void dcd_init(uint8_t rhport) {
+bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
+  (void) rh_init;
   assert(rhport == 0);
 
   TU_LOG(2, "Chip Version B%u\r\n", rp2040_chip_version());
@@ -405,6 +406,7 @@ void dcd_init(uint8_t rhport) {
                  (FORCE_VBUS_DETECT ? 0 : USB_INTS_DEV_CONN_DIS_BITS);
 
   dcd_connect(rhport);
+  return true;
 }
 
 bool dcd_deinit(uint8_t rhport) {

--- a/src/portable/raspberrypi/rp2040/hcd_rp2040.c
+++ b/src/portable/raspberrypi/rp2040/hcd_rp2040.c
@@ -375,9 +375,9 @@ static void _hw_endpoint_init(struct hw_endpoint *ep, uint8_t dev_addr, uint8_t 
 //--------------------------------------------------------------------+
 // HCD API
 //--------------------------------------------------------------------+
-bool hcd_init(uint8_t rhport)
-{
+bool hcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
   (void) rhport;
+  (void) rh_init;
   pico_trace("hcd_init %d\n", rhport);
   assert(rhport == 0);
 

--- a/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
+++ b/src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c
@@ -184,7 +184,8 @@ TU_ATTR_ALWAYS_INLINE static inline xfer_ctl_t *xfer_ctl_ptr(uint8_t epnum, uint
 //--------------------------------------------------------------------+
 // Controller API
 //--------------------------------------------------------------------+
-void dcd_init(uint8_t rhport) {
+bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
+  (void) rh_init;
   // Follow the RM mentions to use a special ordering of PDWN and FRES
   for (volatile uint32_t i = 0; i < 200; i++) { // should be a few us
     asm("NOP");
@@ -223,6 +224,8 @@ void dcd_init(uint8_t rhport) {
 
   // Enable pull-up if supported
   dcd_connect(rhport);
+
+  return true;
 }
 
 void dcd_sof_enable(uint8_t rhport, bool en) {

--- a/src/portable/st/stm32_fsdev/fsdev_stm32.h
+++ b/src/portable/st/stm32_fsdev/fsdev_stm32.h
@@ -170,6 +170,30 @@
   #define USB_CNTR_LPMODE USB_CNTR_SUSPRDY
   #define USB_CNTR_FSUSP USB_CNTR_SUSPEN
 
+#elif CFG_TUSB_MCU == OPT_MCU_STM32U0
+  #include "stm32u0xx.h"
+  #define FSDEV_PMA_SIZE (2048u)
+  #define USB USB_DRD_FS
+
+  #define USB_EP_CTR_RX USB_EP_VTRX
+  #define USB_EP_CTR_TX USB_EP_VTTX
+  #define USB_EP_T_FIELD USB_CHEP_UTYPE
+  #define USB_EPREG_MASK USB_CHEP_REG_MASK
+  #define USB_EPTX_DTOGMASK USB_CHEP_TX_DTOGMASK
+  #define USB_EPRX_DTOGMASK USB_CHEP_RX_DTOGMASK
+  #define USB_EPTX_DTOG1 USB_CHEP_TX_DTOG1
+  #define USB_EPTX_DTOG2 USB_CHEP_TX_DTOG2
+  #define USB_EPRX_DTOG1 USB_CHEP_RX_DTOG1
+  #define USB_EPRX_DTOG2 USB_CHEP_RX_DTOG2
+  #define USB_EPRX_STAT USB_CH_RX_VALID
+  #define USB_EPKIND_MASK USB_EP_KIND_MASK
+  #define USB_CNTR_FRES USB_CNTR_USBRST
+  #define USB_CNTR_RESUME USB_CNTR_L2RES
+  #define USB_ISTR_EP_ID USB_ISTR_IDN
+  #define USB_EPADDR_FIELD USB_CHEP_ADDR
+  #define USB_CNTR_LPMODE USB_CNTR_SUSPRDY
+  #define USB_CNTR_FSUSP USB_CNTR_SUSPEN
+
 #else
   #error You are using an untested or unimplemented STM32 variant. Please update the driver.
   // This includes U0
@@ -249,6 +273,8 @@ static const IRQn_Type fsdev_irq[] = {
     USB_LP_IRQn,
   #elif CFG_TUSB_MCU == OPT_MCU_STM32U5
     USB_IRQn,
+  #elif CFG_TUSB_MCU == OPT_MCU_STM32U0
+    USB_DRD_FS_IRQn,
   #else
     #error Unknown arch in USB driver
   #endif

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -36,6 +36,9 @@
 
 #if CFG_TUD_ENABLED && defined(TUP_USBIP_DWC2)
 
+// Debug level for DWC2
+#define DWC2_DEBUG    2
+
 #include "device/dcd.h"
 #include "dwc2_type.h"
 
@@ -62,29 +65,26 @@
   #error "Unsupported MCUs"
 #endif
 
+enum {
+  DWC2_CONTROLLER_COUNT = TU_ARRAY_SIZE(_dwc2_controller)
+};
+
+// DWC2 registers
+//#define DWC2_REG(_port)       ((dwc2_regs_t*) _dwc2_controller[_port].reg_base)
+
+TU_ATTR_ALWAYS_INLINE static inline dwc2_regs_t* DWC2_REG(uint8_t rhport) {
+  if (rhport >= DWC2_CONTROLLER_COUNT) {
+    // user mis-configured, ignore and use first controller
+    rhport = 0;
+  }
+  return (dwc2_regs_t*) _dwc2_controller[rhport].reg_base;
+}
+
 //--------------------------------------------------------------------+
 // MACRO TYPEDEF CONSTANT ENUM
 //--------------------------------------------------------------------+
 
-// DWC2 registers
-#define DWC2_REG(_port)       ((dwc2_regs_t*) _dwc2_controller[_port].reg_base)
-
-// Debug level for DWC2
-#define DWC2_DEBUG    2
-
-#ifndef dcache_clean
-#define dcache_clean(_addr, _size)
-#endif
-
-#ifndef dcache_invalidate
-#define dcache_invalidate(_addr, _size)
-#endif
-
-#ifndef dcache_clean_invalidate
-#define dcache_clean_invalidate(_addr, _size)
-#endif
-
-static TU_ATTR_ALIGNED(4) uint32_t _setup_packet[2];
+static CFG_TUD_MEM_SECTION TU_ATTR_ALIGNED(4) uint32_t _setup_packet[2];
 
 typedef struct {
   uint8_t* buffer;
@@ -98,98 +98,229 @@ static xfer_ctl_t xfer_status[DWC2_EP_MAX][2];
 #define XFER_CTL_BASE(_ep, _dir) (&xfer_status[_ep][_dir])
 
 // EP0 transfers are limited to 1 packet - larger sizes has to be split
-static uint16_t ep0_pending[2];               // Index determines direction as tusb_dir_t type
+static uint16_t ep0_pending[2];  // Index determines direction as tusb_dir_t type
+static uint16_t _dfifo_top;      // top free location in FIFO RAM
 
-// TX FIFO RAM allocation so far in words - RX FIFO size is readily available from dwc2->grxfsiz
-static uint16_t _allocated_fifo_words_tx;     // TX FIFO size in words (IN EPs)
+// Number of IN endpoints active
+static uint8_t _allocated_ep_in_count;
 
 // SOF enabling flag - required for SOF to not get disabled in ISR when SOF was enabled by
 static bool _sof_en;
 
-// Calculate the RX FIFO size according to minimum recommendations from reference manual
-// RxFIFO = (5 * number of control endpoints + 8) +
-//          ((largest USB packet used / 4) + 1 for status information) +
-//          (2 * number of OUT endpoints) + 1 for Global NAK
-// with number of control endpoints = 1 we have
-// RxFIFO = 15 + (largest USB packet used / 4) + 2 * number of OUT endpoints
-// we double the largest USB packet size to be able to hold up to 2 packets
-static inline uint16_t calc_grxfsiz(uint16_t max_ep_size, uint8_t ep_count) {
-  return 15 + 2 * (max_ep_size / 4) + 2 * ep_count;
+//--------------------------------------------------------------------
+// DMA
+//--------------------------------------------------------------------
+
+TU_ATTR_ALWAYS_INLINE static inline bool dma_enabled(const dwc2_regs_t* dwc2) {
+  #if !CFG_TUD_DWC2_DMA
+  (void) dwc2;
+  return false;
+  #else
+  // Internal DMA only
+  return (dwc2->ghwcfg2_bm.arch == GHWCFG2_ARCH_INTERNAL_DMA);
+  #endif
 }
 
-TU_ATTR_ALWAYS_INLINE static inline void fifo_flush_tx(dwc2_regs_t* dwc2, uint8_t epnum) {
+TU_ATTR_ALWAYS_INLINE static inline uint16_t dma_cal_epfifo_base(uint8_t rhport) {
+  // Scatter/Gather DMA mode is not yet supported. Buffer DMA only need 1 words per endpoint direction
+  const dwc2_controller_t* dwc2_controller = &_dwc2_controller[rhport];
+  return dwc2_controller->ep_fifo_size/4 - 2*dwc2_controller->ep_count;
+}
+
+static void dma_setup_prepare(uint8_t rhport) {
+  dwc2_regs_t* dwc2 = DWC2_REG(rhport);
+
+  if (dwc2->gsnpsid >= DWC2_CORE_REV_3_00a) {
+    if(dwc2->epout[0].doepctl & DOEPCTL_EPENA) {
+      return;
+    }
+  }
+
+  // Receive only 1 packet
+  dwc2->epout[0].doeptsiz = (1 << DOEPTSIZ_STUPCNT_Pos) | (1 << DOEPTSIZ_PKTCNT_Pos) | (8 << DOEPTSIZ_XFRSIZ_Pos);
+  dwc2->epout[0].doepdma = (uintptr_t)_setup_packet;
+  dwc2->epout[0].doepctl |= DOEPCTL_EPENA | DOEPCTL_USBAEP;
+}
+
+//--------------------------------------------------------------------+
+// Data FIFO
+//--------------------------------------------------------------------+
+
+TU_ATTR_ALWAYS_INLINE static inline void dfifo_flush_tx(dwc2_regs_t* dwc2, uint8_t epnum) {
   // flush TX fifo and wait for it cleared
   dwc2->grstctl = GRSTCTL_TXFFLSH | (epnum << GRSTCTL_TXFNUM_Pos);
   while (dwc2->grstctl & GRSTCTL_TXFFLSH_Msk) {}
 }
-TU_ATTR_ALWAYS_INLINE static inline void fifo_flush_rx(dwc2_regs_t* dwc2) {
+TU_ATTR_ALWAYS_INLINE static inline void dfifo_flush_rx(dwc2_regs_t* dwc2) {
   // flush RX fifo and wait for it cleared
   dwc2->grstctl = GRSTCTL_RXFFLSH;
   while (dwc2->grstctl & GRSTCTL_RXFFLSH_Msk) {}
 }
 
-static bool fifo_alloc(uint8_t rhport, uint8_t ep_addr, uint16_t packet_size) {
+/* USB Data FIFO Layout
+
+  The FIFO is split up into
+  - EPInfo: for storing DMA metadata, only required when use DMA. Maximum size is called
+    EP_LOC_CNT = ep_fifo_size - ghwcfg3.dfifo_depth. For value less than EP_LOC_CNT, gdfifocfg must be configured before
+    gahbcfg.dmaen is set
+      - Buffer mode: 1 word per endpoint direction
+      - Scatter/Gather DMA: 4 words per endpoint direction
+  - TX FIFO: one fifo for each IN endpoint. Size is dynamic depending on packet size, starting from top with EP0 IN.
+  - Shared RX FIFO: a shared fifo for all OUT endpoints. Typically, can hold up to 2 packets of the largest EP size.
+
+  We allocated TX FIFO from top to bottom (using top pointer), this to allow the RX FIFO to grow dynamically which is
+  possible since the free space is located between the RX and TX FIFOs.
+
+   ---------------- ep_fifo_size
+  |   EPInfo    |
+  |   for DMA   |
+  |-------------|-- gdfifocfg.EPINFOBASE (max is ghwcfg3.dfifo_depth)
+  | IN FIFO 0   |
+  |  control    |
+  |-------------|
+  | IN FIFO 1   |
+  |-------------|
+  |   . . . .   |
+  |-------------|
+  | IN FIFO n   |
+  |-------------|
+  |    FREE     |
+  |-------------|-- GRXFSIZ (expandable)
+  |  OUT FIFO   |
+  | ( Shared )  |
+  --------------- 0
+
+  According to "FIFO RAM allocation" section in RM, FIFO RAM are allocated as follows (each word 32-bits):
+  - Each EP IN needs at least max packet size
+  - All EP OUT shared a unique OUT FIFO which uses (for Slave or Buffer DMA, Scatt/Gather DMA use different formula):
+    - 13 for setup packets + control words (up to 3 setup packets).
+    - 1 for global NAK (not required/used here).
+    - Largest-EPsize / 4 + 1. ( FS: 64 bytes, HS: 512 bytes). Recommended is  "2 x (Largest-EPsize/4) + 1"
+    - 2 for each used OUT endpoint
+
+    Therefore GRXFSIZ = 13 + 1 + 2 x (Largest-EPsize/4 + 1) + 2 x EPOUTnum
+*/
+
+TU_ATTR_ALWAYS_INLINE static inline uint16_t calc_grxfsiz(uint16_t largest_ep_size, uint8_t ep_count) {
+  return 13 + 1 + 2 * ((largest_ep_size / 4) + 1) + 2 * ep_count;
+}
+
+static bool dfifo_alloc(uint8_t rhport, uint8_t ep_addr, uint16_t packet_size) {
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
-  uint8_t const ep_count = _dwc2_controller[rhport].ep_count;
+  const dwc2_controller_t* dwc2_controller = &_dwc2_controller[rhport];
+  uint8_t const ep_count = dwc2_controller->ep_count;
   uint8_t const epnum = tu_edpt_number(ep_addr);
   uint8_t const dir = tu_edpt_dir(ep_addr);
 
   TU_ASSERT(epnum < ep_count);
 
   uint16_t fifo_size = tu_div_ceil(packet_size, 4);
-
-  // "USB Data FIFOs" section in reference manual
-  // Peripheral FIFO architecture
-  //
-  // --------------- 320 or 1024 ( 1280 or 4096 bytes )
-  // | IN FIFO 0   |
-  // --------------- (320 or 1024) - 16
-  // | IN FIFO 1   |
-  // --------------- (320 or 1024) - 16 - x
-  // |   . . . .   |
-  // --------------- (320 or 1024) - 16 - x - y - ... - z
-  // | IN FIFO MAX |
-  // ---------------
-  // |    FREE     |
-  // --------------- GRXFSIZ
-  // | OUT FIFO    |
-  // | ( Shared )  |
-  // --------------- 0
-  //
-  // In FIFO is allocated by following rules:
-  // - IN EP 1 gets FIFO 1, IN EP "n" gets FIFO "n".
   if (dir == TUSB_DIR_OUT) {
     // Calculate required size of RX FIFO
-    uint16_t const sz = calc_grxfsiz(4 * fifo_size, ep_count);
+    uint16_t const new_sz = calc_grxfsiz(4 * fifo_size, ep_count);
 
-    // If size_rx needs to be extended check if possible and if so enlarge it
-    if (dwc2->grxfsiz < sz) {
-      TU_ASSERT(sz + _allocated_fifo_words_tx <= _dwc2_controller[rhport].ep_fifo_size / 4);
-
-      // Enlarge RX FIFO
-      dwc2->grxfsiz = sz;
+    // If size_rx needs to be extended check if there is enough free space
+    if (dwc2->grxfsiz < new_sz) {
+      TU_ASSERT(new_sz <= _dfifo_top);
+      dwc2->grxfsiz = new_sz; // Enlarge RX FIFO
     }
   } else {
-    // Note if The TXFELVL is configured as half empty. In order
-    // to be able to write a packet at that point, the fifo must be twice the max_size.
+    // Check IN endpoints concurrently active limit
+    if(_dwc2_controller->ep_in_count) {
+      TU_ASSERT(_allocated_ep_in_count < _dwc2_controller->ep_in_count);
+      _allocated_ep_in_count++;
+    }
+
+    // If The TXFELVL is configured as half empty, the fifo must be twice the max_size.
     if ((dwc2->gahbcfg & GAHBCFG_TXFELVL) == 0) {
       fifo_size *= 2;
     }
 
     // Check if free space is available
-    TU_ASSERT(_allocated_fifo_words_tx + fifo_size + dwc2->grxfsiz <= _dwc2_controller[rhport].ep_fifo_size / 4);
-    _allocated_fifo_words_tx += fifo_size;
-    TU_LOG(DWC2_DEBUG, "    Allocated %u bytes at offset %" PRIu32, fifo_size * 4,
-           _dwc2_controller[rhport].ep_fifo_size - _allocated_fifo_words_tx * 4);
+    TU_ASSERT(_dfifo_top >= fifo_size + dwc2->grxfsiz);
+    _dfifo_top -= fifo_size;
+    TU_LOG(DWC2_DEBUG, "    TX FIFO %u: allocated %u words at offset %u\r\n", epnum, fifo_size, _dfifo_top);
 
-    // DIEPTXF starts at FIFO #1.
     // Both TXFD and TXSA are in unit of 32-bit words.
-    dwc2->dieptxf[epnum - 1] = (fifo_size << DIEPTXF_INEPTXFD_Pos) |
-                               (_dwc2_controller[rhport].ep_fifo_size / 4 - _allocated_fifo_words_tx);
+    if (epnum == 0) {
+      dwc2->dieptxf0 = (fifo_size << DIEPTXF0_TX0FD_Pos) | _dfifo_top;
+    } else {
+      // DIEPTXF starts at FIFO #1.
+      dwc2->dieptxf[epnum - 1] = (fifo_size << DIEPTXF_INEPTXFD_Pos) | _dfifo_top;
+    }
   }
 
   return true;
 }
+
+static void dfifo_init(uint8_t rhport) {
+  const dwc2_controller_t* dwc2_controller = &_dwc2_controller[rhport];
+  dwc2_regs_t* dwc2 = DWC2_REG(rhport);
+  dwc2->grxfsiz = calc_grxfsiz(CFG_TUD_ENDPOINT0_SIZE, dwc2_controller->ep_count);
+
+  if(dma_enabled(dwc2)) {
+    // DMA use last DFIFO to store metadata
+    _dfifo_top = dma_cal_epfifo_base(rhport);
+  }else {
+    _dfifo_top = dwc2_controller->ep_fifo_size / 4;
+  }
+
+  // Allocate FIFO for EP0 IN
+  dfifo_alloc(rhport, 0x80, CFG_TUD_ENDPOINT0_SIZE);
+}
+
+// Read a single data packet from receive FIFO
+static void dfifo_read_packet(uint8_t rhport, uint8_t* dst, uint16_t len) {
+  (void) rhport;
+
+  dwc2_regs_t* dwc2 = DWC2_REG(rhport);
+  volatile const uint32_t* rx_fifo = dwc2->fifo[0];
+
+  // Reading full available 32 bit words from fifo
+  uint16_t full_words = len >> 2;
+  while (full_words--) {
+    tu_unaligned_write32(dst, *rx_fifo);
+    dst += 4;
+  }
+
+  // Read the remaining 1-3 bytes from fifo
+  uint8_t const bytes_rem = len & 0x03;
+  if (bytes_rem != 0) {
+    uint32_t const tmp = *rx_fifo;
+    dst[0] = tu_u32_byte0(tmp);
+    if (bytes_rem > 1) dst[1] = tu_u32_byte1(tmp);
+    if (bytes_rem > 2) dst[2] = tu_u32_byte2(tmp);
+  }
+}
+
+// Write a single data packet to EPIN FIFO
+static void dfifo_write_packet(uint8_t rhport, uint8_t fifo_num, uint8_t const* src, uint16_t len) {
+  (void) rhport;
+
+  dwc2_regs_t* dwc2 = DWC2_REG(rhport);
+  volatile uint32_t* tx_fifo = dwc2->fifo[fifo_num];
+
+  // Pushing full available 32 bit words to fifo
+  uint16_t full_words = len >> 2;
+  while (full_words--) {
+    *tx_fifo = tu_unaligned_read32(src);
+    src += 4;
+  }
+
+  // Write the remaining 1-3 bytes into fifo
+  uint8_t const bytes_rem = len & 0x03;
+  if (bytes_rem) {
+    uint32_t tmp_word = src[0];
+    if (bytes_rem > 1) tmp_word |= (src[1] << 8);
+    if (bytes_rem > 2) tmp_word |= (src[2] << 16);
+
+    *tx_fifo = tmp_word;
+  }
+}
+
+//--------------------------------------------------------------------
+// Endpoint
+//--------------------------------------------------------------------
 
 static void edpt_activate(uint8_t rhport, tusb_desc_endpoint_t const * p_endpoint_desc) {
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
@@ -201,53 +332,49 @@ static void edpt_activate(uint8_t rhport, tusb_desc_endpoint_t const * p_endpoin
   xfer->interval = p_endpoint_desc->bInterval;
 
   // USBAEP, EPTYP, SD0PID_SEVNFRM, MPSIZ are the same for IN and OUT endpoints.
-  uint32_t const dxepctl = (1 << DOEPCTL_USBAEP_Pos) |
-                           (p_endpoint_desc->bmAttributes.xfer << DOEPCTL_EPTYP_Pos) |
-                           (p_endpoint_desc->bmAttributes.xfer != TUSB_XFER_ISOCHRONOUS ? DOEPCTL_SD0PID_SEVNFRM : 0) |
-                           (xfer->max_size << DOEPCTL_MPSIZ_Pos);
-
-  if (dir == TUSB_DIR_OUT) {
-    dwc2->epout[epnum].doepctl = dxepctl;
-    dwc2->daintmsk |= TU_BIT(DAINTMSK_OEPM_Pos + epnum);
-  } else {
-    dwc2->epin[epnum].diepctl = dxepctl | (epnum << DIEPCTL_TXFNUM_Pos);
-    dwc2->daintmsk |= (1 << (DAINTMSK_IEPM_Pos + epnum));
+  uint32_t epctl = (1 << DOEPCTL_USBAEP_Pos) |
+                   (p_endpoint_desc->bmAttributes.xfer << DOEPCTL_EPTYP_Pos) |
+                   (p_endpoint_desc->bmAttributes.xfer != TUSB_XFER_ISOCHRONOUS ? DOEPCTL_SD0PID_SEVNFRM : 0) |
+                   (xfer->max_size << DOEPCTL_MPSIZ_Pos);
+  if (dir == TUSB_DIR_IN) {
+    epctl |= (epnum << DIEPCTL_TXFNUM_Pos);
   }
+
+  dwc2_dep_t* dep = &dwc2->ep[1 - dir][epnum];
+  dep->ctl = epctl;
+  dwc2->daintmsk |= TU_BIT(epnum + DAINT_SHIFT(dir));
 }
 
 static void edpt_disable(uint8_t rhport, uint8_t ep_addr, bool stall) {
   (void) rhport;
 
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
-  uint8_t const epnum = tu_edpt_number(ep_addr);
-  uint8_t const dir = tu_edpt_dir(ep_addr);
+  const uint8_t epnum = tu_edpt_number(ep_addr);
+  const uint8_t dir = tu_edpt_dir(ep_addr);
+  dwc2_dep_t* dep = &dwc2->ep[1 - dir][epnum];
 
   if (dir == TUSB_DIR_IN) {
-    dwc2_epin_t* epin = dwc2->epin;
-
     // Only disable currently enabled non-control endpoint
-    if ((epnum == 0) || !(epin[epnum].diepctl & DIEPCTL_EPENA)) {
-      epin[epnum].diepctl |= DIEPCTL_SNAK | (stall ? DIEPCTL_STALL : 0);
+    if ((epnum == 0) || !(dep->diepctl & DIEPCTL_EPENA)) {
+      dep->diepctl |= DIEPCTL_SNAK | (stall ? DIEPCTL_STALL : 0);
     } else {
       // Stop transmitting packets and NAK IN xfers.
-      epin[epnum].diepctl |= DIEPCTL_SNAK;
-      while ((epin[epnum].diepint & DIEPINT_INEPNE) == 0) {}
+      dep->diepctl |= DIEPCTL_SNAK;
+      while ((dep->diepint & DIEPINT_INEPNE) == 0) {}
 
       // Disable the endpoint.
-      epin[epnum].diepctl |= DIEPCTL_EPDIS | (stall ? DIEPCTL_STALL : 0);
-      while ((epin[epnum].diepint & DIEPINT_EPDISD_Msk) == 0) {}
+      dep->diepctl |= DIEPCTL_EPDIS | (stall ? DIEPCTL_STALL : 0);
+      while ((dep->diepint & DIEPINT_EPDISD_Msk) == 0) {}
 
-      epin[epnum].diepint = DIEPINT_EPDISD;
+      dep->diepint = DIEPINT_EPDISD;
     }
 
     // Flush the FIFO, and wait until we have confirmed it cleared.
-    fifo_flush_tx(dwc2, epnum);
+    dfifo_flush_tx(dwc2, epnum);
   } else {
-    dwc2_epout_t* epout = dwc2->epout;
-
     // Only disable currently enabled non-control endpoint
-    if ((epnum == 0) || !(epout[epnum].doepctl & DOEPCTL_EPENA)) {
-      epout[epnum].doepctl |= stall ? DOEPCTL_STALL : 0;
+    if ((epnum == 0) || !(dep->doepctl & DOEPCTL_EPENA)) {
+      dep->doepctl |= stall ? DOEPCTL_STALL : 0;
     } else {
       // Asserting GONAK is required to STALL an OUT endpoint.
       // Simpler to use polling here, we don't use the "B"OUTNAKEFF interrupt
@@ -256,11 +383,11 @@ static void edpt_disable(uint8_t rhport, uint8_t ep_addr, bool stall) {
       dwc2->dctl |= DCTL_SGONAK;
       while ((dwc2->gintsts & GINTSTS_BOUTNAKEFF_Msk) == 0) {}
 
-      // Ditto here- disable the endpoint.
-      epout[epnum].doepctl |= DOEPCTL_EPDIS | (stall ? DOEPCTL_STALL : 0);
-      while ((epout[epnum].doepint & DOEPINT_EPDISD_Msk) == 0) {}
+      // Ditto here disable the endpoint.
+      dep->doepctl |= DOEPCTL_EPDIS | (stall ? DOEPCTL_STALL : 0);
+      while ((dep->doepint & DOEPINT_EPDISD_Msk) == 0) {}
 
-      epout[epnum].doepint = DOEPINT_EPDISD;
+      dep->doepint = DOEPINT_EPDISD;
 
       // Allow other OUT endpoints to keep receiving.
       dwc2->dctl |= DCTL_CGONAK;
@@ -276,9 +403,7 @@ static void bus_reset(uint8_t rhport) {
   tu_memclr(xfer_status, sizeof(xfer_status));
 
   _sof_en = false;
-
-  // clear device address
-  dwc2->dcfg &= ~DCFG_DAD_Msk;
+  _allocated_ep_in_count = 1;
 
   // 1. NAK for all OUT endpoints
   for (uint8_t n = 0; n < ep_count; n++) {
@@ -292,79 +417,32 @@ static void bus_reset(uint8_t rhport) {
     }
   }
 
-  fifo_flush_tx(dwc2, 0x10); // all tx fifo
-  fifo_flush_rx(dwc2);
+  dfifo_flush_tx(dwc2, 0x10); // all tx fifo
+  dfifo_flush_rx(dwc2);
 
-  // 3. Set up interrupt mask
+  // 3. Set up interrupt mask for EP0
   dwc2->daintmsk = TU_BIT(DAINTMSK_OEPM_Pos) | TU_BIT(DAINTMSK_IEPM_Pos);
   dwc2->doepmsk = DOEPMSK_STUPM | DOEPMSK_XFRCM;
   dwc2->diepmsk = DIEPMSK_TOM | DIEPMSK_XFRCM;
 
-  // "USB Data FIFOs" section in reference manual
-  // Peripheral FIFO architecture
-  //
-  // The FIFO is split up in a lower part where the RX FIFO is located and an upper part where the TX FIFOs start.
-  // We do this to allow the RX FIFO to grow dynamically which is possible since the free space is located
-  // between the RX and TX FIFOs. This is required by ISO OUT EPs which need a bigger FIFO than the standard
-  // configuration done below.
-  //
-  // Dynamically FIFO sizes are of interest only for ISO EPs since all others are usually not opened and closed.
-  // All EPs other than ISO are opened as soon as the driver starts up i.e. when the host sends a
-  // configure interface command. Hence, all IN EPs other the ISO will be located at the top. IN ISO EPs are usually
-  // opened when the host sends an additional command: setInterface. At this point in time
-  // the ISO EP will be located next to the free space and can change its size. In case more IN EPs change its size
-  // an additional memory
-  //
-  // --------------- 320 or 1024 ( 1280 or 4096 bytes )
-  // | IN FIFO 0   |
-  // --------------- (320 or 1024) - 16
-  // | IN FIFO 1   |
-  // --------------- (320 or 1024) - 16 - x
-  // |   . . . .   |
-  // --------------- (320 or 1024) - 16 - x - y - ... - z
-  // | IN FIFO MAX |
-  // ---------------
-  // |    FREE     |
-  // --------------- GRXFSIZ
-  // | OUT FIFO    |
-  // | ( Shared )  |
-  // --------------- 0
-  //
-  // According to "FIFO RAM allocation" section in RM, FIFO RAM are allocated as follows (each word 32-bits):
-  // - Each EP IN needs at least max packet size, 16 words is sufficient for EP0 IN
-  //
-  // - All EP OUT shared a unique OUT FIFO which uses
-  //   - 13 for setup packets + control words (up to 3 setup packets).
-  //   - 1 for global NAK (not required/used here).
-  //   - Largest-EPsize / 4 + 1. ( FS: 64 bytes, HS: 512 bytes). Recommended is  "2 x (Largest-EPsize/4) + 1"
-  //   - 2 for each used OUT endpoint
-  //
-  //   Therefore GRXFSIZ = 13 + 1 + 1 + 2 x (Largest-EPsize/4) + 2 x EPOUTnum
-  //   - FullSpeed (64 Bytes ): GRXFSIZ = 15 + 2 x  16 + 2 x ep_count = 47  + 2 x ep_count
-  //   - Highspeed (512 bytes): GRXFSIZ = 15 + 2 x 128 + 2 x ep_count = 271 + 2 x ep_count
-  //
-  //   NOTE: Largest-EPsize & EPOUTnum is actual used endpoints in configuration. Since DCD has no knowledge
-  //   of the overall picture yet. We will use the worst scenario: largest possible + ep_count
-  //
-  //   For Isochronous, largest EP size can be 1023/1024 for FS/HS respectively. In addition if multiple ISO
-  //   are enabled at least "2 x (Largest-EPsize/4) + 1" are recommended.  Maybe provide a macro for application to
-  //   overwrite this.
+  // 4. Set up DFIFO
+  dfifo_init(rhport);
 
-  // EP0 out max is 64
-  dwc2->grxfsiz = calc_grxfsiz(64, ep_count);
+  // 5. Reset device address
+  dwc2->dcfg &= ~DCFG_DAD_Msk;
 
-  // Setup the control endpoint 0
-  _allocated_fifo_words_tx = 16;
-
-  // Control IN uses FIFO 0 with 64 bytes ( 16 32-bit word )
-  dwc2->dieptxf0 = (16 << DIEPTXF0_TX0FD_Pos) | (_dwc2_controller[rhport].ep_fifo_size / 4 - _allocated_fifo_words_tx);
-
-  // Fixed control EP0 size to 64 bytes
+  // Fixed both control EP0 size to 64 bytes
   dwc2->epin[0].diepctl &= ~(0x03 << DIEPCTL_MPSIZ_Pos);
+  dwc2->epout[0].doepctl &= ~(0x03 << DOEPCTL_MPSIZ_Pos);
+
   xfer_status[0][TUSB_DIR_OUT].max_size = 64;
   xfer_status[0][TUSB_DIR_IN].max_size = 64;
 
-  dwc2->epout[0].doeptsiz |= (3 << DOEPTSIZ_STUPCNT_Pos);
+  if(dma_enabled(dwc2)) {
+    dma_setup_prepare(rhport);
+  } else {
+    dwc2->epout[0].doeptsiz |= (3 << DOEPTSIZ_STUPCNT_Pos);
+  }
 
   dwc2->gintmsk |= GINTMSK_OEPINT | GINTMSK_IEPINT;
 }
@@ -374,68 +452,73 @@ static void edpt_schedule_packets(uint8_t rhport, uint8_t const epnum, uint8_t c
   (void) rhport;
 
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
+  xfer_ctl_t* const xfer = XFER_CTL_BASE(epnum, dir);
 
   // EP0 is limited to one packet each xfer
   // We use multiple transaction of xfer->max_size length to get a whole transfer done
   if (epnum == 0) {
-    xfer_ctl_t* const xfer = XFER_CTL_BASE(epnum, dir);
     total_bytes = tu_min16(ep0_pending[dir], xfer->max_size);
     ep0_pending[dir] -= total_bytes;
   }
 
   // IN and OUT endpoint xfers are interrupt-driven, we just schedule them here.
-  if (dir == TUSB_DIR_IN) {
-    dwc2_epin_t* epin = dwc2->epin;
+  const uint8_t is_epout = 1 - dir;
+  dwc2_dep_t* dep = &dwc2->ep[is_epout][epnum];
 
+  if (dir == TUSB_DIR_IN) {
     // A full IN transfer (multiple packets, possibly) triggers XFRC.
-    epin[epnum].dieptsiz = (num_packets << DIEPTSIZ_PKTCNT_Pos) |
+    dep->dieptsiz = (num_packets << DIEPTSIZ_PKTCNT_Pos) |
                            ((total_bytes << DIEPTSIZ_XFRSIZ_Pos) & DIEPTSIZ_XFRSIZ_Msk);
 
-    epin[epnum].diepctl |= DIEPCTL_EPENA | DIEPCTL_CNAK;
+    if(dma_enabled(dwc2)) {
+      dep->diepdma = (uintptr_t)xfer->buffer;
 
-    // For ISO endpoint set correct odd/even bit for next frame.
-    if ((epin[epnum].diepctl & DIEPCTL_EPTYP) == DIEPCTL_EPTYP_0 && (XFER_CTL_BASE(epnum, dir))->interval == 1) {
-      // Take odd/even bit from frame counter.
-      uint32_t const odd_frame_now = (dwc2->dsts & (1u << DSTS_FNSOF_Pos));
-      epin[epnum].diepctl |= (odd_frame_now ? DIEPCTL_SD0PID_SEVNFRM_Msk : DIEPCTL_SODDFRM_Msk);
-    }
-    // Enable fifo empty interrupt only if there are something to put in the fifo.
-    if (total_bytes != 0) {
-      dwc2->diepempmsk |= (1 << epnum);
+      // For ISO endpoint set correct odd/even bit for next frame.
+      if ((dep->diepctl & DIEPCTL_EPTYP) == DIEPCTL_EPTYP_0 && (XFER_CTL_BASE(epnum, dir))->interval == 1) {
+        // Take odd/even bit from frame counter.
+        uint32_t const odd_frame_now = (dwc2->dsts & (1u << DSTS_FNSOF_Pos));
+        dep->diepctl |= (odd_frame_now ? DIEPCTL_SD0PID_SEVNFRM_Msk : DIEPCTL_SODDFRM_Msk);
+      }
+
+      dep->diepctl |= DIEPCTL_EPENA | DIEPCTL_CNAK;
+    } else {
+      dep->diepctl |= DIEPCTL_EPENA | DIEPCTL_CNAK;
+
+      // For ISO endpoint set correct odd/even bit for next frame.
+      if ((dep->diepctl & DIEPCTL_EPTYP) == DIEPCTL_EPTYP_0 && (XFER_CTL_BASE(epnum, dir))->interval == 1) {
+        // Take odd/even bit from frame counter.
+        uint32_t const odd_frame_now = (dwc2->dsts & (1u << DSTS_FNSOF_Pos));
+        dep->diepctl |= (odd_frame_now ? DIEPCTL_SD0PID_SEVNFRM_Msk : DIEPCTL_SODDFRM_Msk);
+      }
+      // Enable fifo empty interrupt only if there are something to put in the fifo.
+      if (total_bytes != 0) {
+        dwc2->diepempmsk |= (1 << epnum);
+      }
     }
   } else {
-    dwc2_epout_t* epout = dwc2->epout;
-
     // A full OUT transfer (multiple packets, possibly) triggers XFRC.
-    epout[epnum].doeptsiz &= ~(DOEPTSIZ_PKTCNT_Msk | DOEPTSIZ_XFRSIZ);
-    epout[epnum].doeptsiz |= (num_packets << DOEPTSIZ_PKTCNT_Pos) |
+    dep->doeptsiz &= ~(DOEPTSIZ_PKTCNT_Msk | DOEPTSIZ_XFRSIZ);
+    dep->doeptsiz |= (num_packets << DOEPTSIZ_PKTCNT_Pos) |
                              ((total_bytes << DOEPTSIZ_XFRSIZ_Pos) & DOEPTSIZ_XFRSIZ_Msk);
 
-    epout[epnum].doepctl |= DOEPCTL_EPENA | DOEPCTL_CNAK;
-    if ((epout[epnum].doepctl & DOEPCTL_EPTYP) == DOEPCTL_EPTYP_0 &&
+    if ((dep->doepctl & DOEPCTL_EPTYP) == DOEPCTL_EPTYP_0 &&
         XFER_CTL_BASE(epnum, dir)->interval == 1) {
       // Take odd/even bit from frame counter.
       uint32_t const odd_frame_now = (dwc2->dsts & (1u << DSTS_FNSOF_Pos));
-      epout[epnum].doepctl |= (odd_frame_now ? DOEPCTL_SD0PID_SEVNFRM_Msk : DOEPCTL_SODDFRM_Msk);
+      dep->doepctl |= (odd_frame_now ? DOEPCTL_SD0PID_SEVNFRM_Msk : DOEPCTL_SODDFRM_Msk);
     }
+
+    if(dma_enabled(dwc2)) {
+      dep->doepdma = (uintptr_t)xfer->buffer;
+    }
+
+    dep->doepctl |= DOEPCTL_EPENA | DOEPCTL_CNAK;
   }
 }
 
 /*------------------------------------------------------------------*/
 /* Controller API
  *------------------------------------------------------------------*/
-#if CFG_TUSB_DEBUG >= DWC2_DEBUG
-void print_dwc2_info(dwc2_regs_t* dwc2) {
-  // print guid, gsnpsid, ghwcfg1, ghwcfg2, ghwcfg3, ghwcfg4
-  // use dwc2_info.py/md for bit-field value and comparison with other ports
-  volatile uint32_t const* p = (volatile uint32_t const*) &dwc2->guid;
-  TU_LOG(DWC2_DEBUG, "guid, gsnpsid, ghwcfg1, ghwcfg2, ghwcfg3, ghwcfg4\r\n");
-  for (size_t i = 0; i < 5; i++) {
-    TU_LOG(DWC2_DEBUG, "0x%08" PRIX32 ", ", p[i]);
-  }
-  TU_LOG(DWC2_DEBUG, "0x%08" PRIX32 "\r\n", p[5]);
-}
-#endif
 
 static void reset_core(dwc2_regs_t* dwc2) {
   // reset core
@@ -454,13 +537,10 @@ static void reset_core(dwc2_regs_t* dwc2) {
 static bool phy_hs_supported(dwc2_regs_t* dwc2) {
   (void) dwc2;
 
-#if TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3)
-  // note: esp32 incorrect report its hs_phy_type as utmi
-  return false;
-#elif !TUD_OPT_HIGH_SPEED
+#if !TUD_OPT_HIGH_SPEED
   return false;
 #else
-  return dwc2->ghwcfg2_bm.hs_phy_type != HS_PHY_TYPE_NONE;
+  return dwc2->ghwcfg2_bm.hs_phy_type != GHWCFG2_HSPHY_NOT_SUPPORTED;
 #endif
 }
 
@@ -471,7 +551,7 @@ static void phy_fs_init(dwc2_regs_t* dwc2) {
   dwc2->gusbcfg |= GUSBCFG_PHYSEL;
 
   // MCU specific PHY init before reset
-  dwc2_phy_init(dwc2, HS_PHY_TYPE_NONE);
+  dwc2_phy_init(dwc2, GHWCFG2_HSPHY_NOT_SUPPORTED);
 
   // Reset core after selecting PHY
   reset_core(dwc2);
@@ -482,7 +562,7 @@ static void phy_fs_init(dwc2_regs_t* dwc2) {
   dwc2->gusbcfg = (dwc2->gusbcfg & ~GUSBCFG_TRDT_Msk) | (5u << GUSBCFG_TRDT_Pos);
 
   // MCU specific PHY update post reset
-  dwc2_phy_update(dwc2, HS_PHY_TYPE_NONE);
+  dwc2_phy_update(dwc2, GHWCFG2_HSPHY_NOT_SUPPORTED);
 
   // set max speed
   dwc2->dcfg = (dwc2->dcfg & ~DCFG_DSPD_Msk) | (DCFG_DSPD_FS << DCFG_DSPD_Pos);
@@ -494,7 +574,7 @@ static void phy_hs_init(dwc2_regs_t* dwc2) {
   // De-select FS PHY
   gusbcfg &= ~GUSBCFG_PHYSEL;
 
-  if (dwc2->ghwcfg2_bm.hs_phy_type == HS_PHY_TYPE_ULPI) {
+  if (dwc2->ghwcfg2_bm.hs_phy_type == GHWCFG2_HSPHY_ULPI) {
     TU_LOG(DWC2_DEBUG, "Highspeed ULPI PHY init\r\n");
 
     // Select ULPI
@@ -515,7 +595,9 @@ static void phy_hs_init(dwc2_regs_t* dwc2) {
     gusbcfg &= ~(GUSBCFG_ULPI_UTMI_SEL | GUSBCFG_PHYIF16);
 
     // Set 16-bit interface if supported
-    if (dwc2->ghwcfg4_bm.utmi_phy_data_width) gusbcfg |= GUSBCFG_PHYIF16;
+    if (dwc2->ghwcfg4_bm.phy_data_width) {
+      gusbcfg |= GUSBCFG_PHYIF16;
+    }
   }
 
   // Apply config
@@ -531,7 +613,7 @@ static void phy_hs_init(dwc2_regs_t* dwc2) {
   // - 9 if using 8-bit PHY interface
   // - 5 if using 16-bit PHY interface
   gusbcfg &= ~GUSBCFG_TRDT_Msk;
-  gusbcfg |= (dwc2->ghwcfg4_bm.utmi_phy_data_width ? 5u : 9u) << GUSBCFG_TRDT_Pos;
+  gusbcfg |= (dwc2->ghwcfg4_bm.phy_data_width ? 5u : 9u) << GUSBCFG_TRDT_Pos;
   dwc2->gusbcfg = gusbcfg;
 
   // MCU specific PHY update post reset
@@ -544,17 +626,26 @@ static void phy_hs_init(dwc2_regs_t* dwc2) {
 
   // XCVRDLY: transceiver delay between xcvr_sel and txvalid during device chirp is required
   // when using with some PHYs such as USB334x (USB3341, USB3343, USB3346, USB3347)
-  if (dwc2->ghwcfg2_bm.hs_phy_type == HS_PHY_TYPE_ULPI) dcfg |= DCFG_XCVRDLY;
+  if (dwc2->ghwcfg2_bm.hs_phy_type == GHWCFG2_HSPHY_ULPI) {
+    dcfg |= DCFG_XCVRDLY;
+  }
 
   dwc2->dcfg = dcfg;
 }
 
 static bool check_dwc2(dwc2_regs_t* dwc2) {
 #if CFG_TUSB_DEBUG >= DWC2_DEBUG
-  print_dwc2_info(dwc2);
+  // print guid, gsnpsid, ghwcfg1, ghwcfg2, ghwcfg3, ghwcfg4
+  // Run 'python dwc2_info.py' and check dwc2_info.md for bit-field value and comparison with other ports
+  volatile uint32_t const* p = (volatile uint32_t const*) &dwc2->guid;
+  TU_LOG1("guid, gsnpsid, ghwcfg1, ghwcfg2, ghwcfg3, ghwcfg4\r\n");
+  for (size_t i = 0; i < 5; i++) {
+    TU_LOG1("0x%08" PRIX32 ", ", p[i]);
+  }
+  TU_LOG1("0x%08" PRIX32 "\r\n", p[5]);
 #endif
 
-  // For some reasons: GD32VF103 snpsid and all hwcfg register are always zero (skip it)
+  // For some reason: GD32VF103 snpsid and all hwcfg register are always zero (skip it)
   (void) dwc2;
 #if !TU_CHECK_MCU(OPT_MCU_GD32VF103)
   uint32_t const gsnpsid = dwc2->gsnpsid & GSNPSID_ID_MASK;
@@ -564,17 +655,16 @@ static bool check_dwc2(dwc2_regs_t* dwc2) {
   return true;
 }
 
-void dcd_init(uint8_t rhport) {
+bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
+  (void) rhport;
+  (void) rh_init;
   // Programming model begins in the last section of the chapter on the USB
   // peripheral in each Reference Manual.
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
 
   // Check Synopsys ID register, failed if controller clock/power is not enabled
-  if (!check_dwc2(dwc2)) return;
+  TU_ASSERT(check_dwc2(dwc2));
   dcd_disconnect(rhport);
-
-  // max number of endpoints & total_fifo_size are:
-  // hw_cfg2->num_dev_ep, hw_cfg2->total_fifo_size
 
   if (phy_hs_supported(dwc2)) {
     phy_hs_init(dwc2); // Highspeed
@@ -605,8 +695,8 @@ void dcd_init(uint8_t rhport) {
   // (non zero-length packet), send STALL back and discard.
   dwc2->dcfg |= DCFG_NZLSOHSK;
 
-  fifo_flush_tx(dwc2, 0x10); // all tx fifo
-  fifo_flush_rx(dwc2);
+  dfifo_flush_tx(dwc2, 0x10); // all tx fifo
+  dfifo_flush_rx(dwc2);
 
   // Clear all interrupts
   uint32_t int_mask = dwc2->gintsts;
@@ -615,11 +705,20 @@ void dcd_init(uint8_t rhport) {
   dwc2->gotgint |= int_mask;
 
   // Required as part of core initialization.
-  dwc2->gintmsk = GINTMSK_OTGINT | GINTMSK_RXFLVLM |
-                  GINTMSK_USBSUSPM | GINTMSK_USBRST | GINTMSK_ENUMDNEM | GINTMSK_WUIM;
+  dwc2->gintmsk = GINTMSK_OTGINT | GINTMSK_USBSUSPM | GINTMSK_USBRST | GINTMSK_ENUMDNEM | GINTMSK_WUIM;
 
   // Configure TX FIFO empty level for interrupt. Default is complete empty
   dwc2->gahbcfg |= GAHBCFG_TXFELVL;
+
+  if (dma_enabled(dwc2)) {
+    const uint16_t epinfo_base = dma_cal_epfifo_base(rhport);
+    dwc2->gdfifocfg = (epinfo_base << GDFIFOCFG_EPINFOBASE_SHIFT) | epinfo_base;
+
+    // DMA seems to be only settable after a core reset
+    dwc2->gahbcfg |= GAHBCFG_DMAEN | GAHBCFG_HBSTLEN_2;
+  }else {
+    dwc2->gintmsk |= GINTMSK_RXFLVLM;
+  }
 
   // Enable global interrupt
   dwc2->gahbcfg |= GAHBCFG_GINT;
@@ -633,6 +732,8 @@ void dcd_init(uint8_t rhport) {
 //  TU_LOG_HEX(DWC2_DEBUG, dwc2->gahbcfg);
 
   dcd_connect(rhport);
+
+  return true;
 }
 
 void dcd_int_enable(uint8_t rhport) {
@@ -723,7 +824,7 @@ void dcd_sof_enable(uint8_t rhport, bool en) {
  *------------------------------------------------------------------*/
 
 bool dcd_edpt_open(uint8_t rhport, tusb_desc_endpoint_t const* desc_edpt) {
-  TU_ASSERT(fifo_alloc(rhport, desc_edpt->bEndpointAddress, tu_edpt_packet_size(desc_edpt)));
+  TU_ASSERT(dfifo_alloc(rhport, desc_edpt->bEndpointAddress, tu_edpt_packet_size(desc_edpt)));
   edpt_activate(rhport, desc_edpt);
   return true;
 }
@@ -733,43 +834,36 @@ void dcd_edpt_close_all(uint8_t rhport) {
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
   uint8_t const ep_count = _dwc2_controller[rhport].ep_count;
 
+  _allocated_ep_in_count = 1;
+
   // Disable non-control interrupt
   dwc2->daintmsk = (1 << DAINTMSK_OEPM_Pos) | (1 << DAINTMSK_IEPM_Pos);
 
   for (uint8_t n = 1; n < ep_count; n++) {
-    // disable OUT endpoint
-    if (dwc2->epout[n].doepctl & DOEPCTL_EPENA) {
-      dwc2->epout[n].doepctl |= DOEPCTL_SNAK | DOEPCTL_EPDIS;
+    for (uint8_t d = 0; d < 2; d++) {
+      dwc2_dep_t* dep = &dwc2->ep[d][n];
+      if (dep->ctl & EPCTL_EPENA) {
+        dep->ctl |= EPCTL_SNAK | EPCTL_EPDIS;
+      }
+      xfer_status[n][1-d].max_size = 0;
     }
-    xfer_status[n][TUSB_DIR_OUT].max_size = 0;
-
-    // disable IN endpoint
-    if (dwc2->epin[n].diepctl & DIEPCTL_EPENA) {
-      dwc2->epin[n].diepctl |= DIEPCTL_SNAK | DIEPCTL_EPDIS;
-    }
-    xfer_status[n][TUSB_DIR_IN].max_size = 0;
   }
 
-  // reset allocated fifo OUT
-  dwc2->grxfsiz = calc_grxfsiz(64, ep_count);
-  // reset allocated fifo IN
-  _allocated_fifo_words_tx = 16;
+  dfifo_flush_tx(dwc2, 0x10); // all tx fifo
+  dfifo_flush_rx(dwc2);
 
-  fifo_flush_tx(dwc2, 0x10); // all tx fifo
-  fifo_flush_rx(dwc2);
+  dfifo_init(rhport); // re-init dfifo
 }
 
 bool dcd_edpt_iso_alloc(uint8_t rhport, uint8_t ep_addr, uint16_t largest_packet_size) {
-  TU_ASSERT(fifo_alloc(rhport, ep_addr, largest_packet_size));
+  TU_ASSERT(dfifo_alloc(rhport, ep_addr, largest_packet_size));
   return true;
 }
 
 bool dcd_edpt_iso_activate(uint8_t rhport,  tusb_desc_endpoint_t const * p_endpoint_desc) {
   // Disable EP to clear potential incomplete transfers
   edpt_disable(rhport, p_endpoint_desc->bEndpointAddress, false);
-
   edpt_activate(rhport, p_endpoint_desc);
-
   return true;
 }
 
@@ -822,7 +916,9 @@ bool dcd_edpt_xfer_fifo(uint8_t rhport, uint8_t ep_addr, tu_fifo_t* ff, uint16_t
   uint16_t const short_packet_size = total_bytes % xfer->max_size;
 
   // Zero-size packet is special case.
-  if (short_packet_size > 0 || (total_bytes == 0)) num_packets++;
+  if (short_packet_size > 0 || (total_bytes == 0)) {
+    num_packets++;
+  }
 
   // Schedule packets to be sent within interrupt
   edpt_schedule_packets(rhport, epnum, dir, num_packets, total_bytes);
@@ -836,99 +932,37 @@ void dcd_edpt_close(uint8_t rhport, uint8_t ep_addr) {
 
 void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr) {
   edpt_disable(rhport, ep_addr, true);
+  if((tu_edpt_number(ep_addr) == 0) && dma_enabled(DWC2_REG(rhport))) {
+    dma_setup_prepare(rhport);
+  }
 }
 
 void dcd_edpt_clear_stall(uint8_t rhport, uint8_t ep_addr) {
-  (void) rhport;
-
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
-
   uint8_t const epnum = tu_edpt_number(ep_addr);
   uint8_t const dir = tu_edpt_dir(ep_addr);
+  dwc2_dep_t* dep = &dwc2->ep[1 - dir][epnum];
 
   // Clear stall and reset data toggle
-  if (dir == TUSB_DIR_IN) {
-    dwc2->epin[epnum].diepctl &= ~DIEPCTL_STALL;
-    dwc2->epin[epnum].diepctl |= DIEPCTL_SD0PID_SEVNFRM;
-  } else {
-    dwc2->epout[epnum].doepctl &= ~DOEPCTL_STALL;
-    dwc2->epout[epnum].doepctl |= DOEPCTL_SD0PID_SEVNFRM;
-  }
+  dep->ctl &= ~EPCTL_STALL;;
+  dep->ctl |= EPCTL_SD0PID_SEVNFRM;
 }
 
-/*------------------------------------------------------------------*/
+//--------------------------------------------------------------------
+// Interrupt Handler
+//--------------------------------------------------------------------
 
-// Read a single data packet from receive FIFO
-static void read_fifo_packet(uint8_t rhport, uint8_t* dst, uint16_t len) {
-  (void) rhport;
-
-  dwc2_regs_t* dwc2 = DWC2_REG(rhport);
-  volatile const uint32_t* rx_fifo = dwc2->fifo[0];
-
-  // Reading full available 32 bit words from fifo
-  uint16_t full_words = len >> 2;
-  while (full_words--) {
-    tu_unaligned_write32(dst, *rx_fifo);
-    dst += 4;
-  }
-
-  // Read the remaining 1-3 bytes from fifo
-  uint8_t const bytes_rem = len & 0x03;
-  if (bytes_rem != 0) {
-    uint32_t const tmp = *rx_fifo;
-    dst[0] = tu_u32_byte0(tmp);
-    if (bytes_rem > 1) dst[1] = tu_u32_byte1(tmp);
-    if (bytes_rem > 2) dst[2] = tu_u32_byte2(tmp);
-  }
-}
-
-// Write a single data packet to EPIN FIFO
-static void write_fifo_packet(uint8_t rhport, uint8_t fifo_num, uint8_t const* src, uint16_t len) {
-  (void) rhport;
-
-  dwc2_regs_t* dwc2 = DWC2_REG(rhport);
-  volatile uint32_t* tx_fifo = dwc2->fifo[fifo_num];
-
-  // Pushing full available 32 bit words to fifo
-  uint16_t full_words = len >> 2;
-  while (full_words--) {
-    *tx_fifo = tu_unaligned_read32(src);
-    src += 4;
-  }
-
-  // Write the remaining 1-3 bytes into fifo
-  uint8_t const bytes_rem = len & 0x03;
-  if (bytes_rem) {
-    uint32_t tmp_word = src[0];
-    if (bytes_rem > 1) tmp_word |= (src[1] << 8);
-    if (bytes_rem > 2) tmp_word |= (src[2] << 16);
-
-    *tx_fifo = tmp_word;
-  }
-}
-
+// Process shared receive FIFO, this interrupt is only used in Slave mode
 static void handle_rxflvl_irq(uint8_t rhport) {
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
   volatile uint32_t const* rx_fifo = dwc2->fifo[0];
 
   // Pop control word off FIFO
-  uint32_t const ctl_word = dwc2->grxstsp;
-  uint8_t const pktsts = (ctl_word & GRXSTSP_PKTSTS_Msk) >> GRXSTSP_PKTSTS_Pos;
-  uint8_t const epnum = (ctl_word & GRXSTSP_EPNUM_Msk) >> GRXSTSP_EPNUM_Pos;
-  uint16_t const bcnt = (ctl_word & GRXSTSP_BCNT_Msk) >> GRXSTSP_BCNT_Pos;
-
+  uint32_t const grxstsp = dwc2->grxstsp;
+  uint8_t const pktsts = (grxstsp & GRXSTSP_PKTSTS_Msk) >> GRXSTSP_PKTSTS_Pos;
+  uint8_t const epnum = (grxstsp & GRXSTSP_EPNUM_Msk) >> GRXSTSP_EPNUM_Pos;
+  uint16_t const bcnt = (grxstsp & GRXSTSP_BCNT_Msk) >> GRXSTSP_BCNT_Pos;
   dwc2_epout_t* epout = &dwc2->epout[epnum];
-
-//#if CFG_TUSB_DEBUG >= DWC2_DEBUG
-//  const char * pktsts_str[] =
-//  {
-//    "ASSERT", "Global NAK (ISR)", "Out Data Received", "Out Transfer Complete (ISR)",
-//    "Setup Complete (ISR)", "ASSERT", "Setup Data Received"
-//  };
-//  TU_LOG_LOCATION();
-//  TU_LOG(DWC2_DEBUG, "  EP %02X, Byte Count %u, %s\r\n", epnum, bcnt, pktsts_str[pktsts]);
-//  TU_LOG(DWC2_DEBUG, "  daint = %08lX, doepint = %04X\r\n", (unsigned long) dwc2->daint, (unsigned int) epout->doepint);
-//#endif
 
   switch (pktsts) {
     // Global OUT NAK: do nothing
@@ -937,15 +971,14 @@ static void handle_rxflvl_irq(uint8_t rhport) {
 
     case GRXSTS_PKTSTS_SETUPRX:
       // Setup packet received
-
-      // We can receive up to three setup packets in succession, but
-      // only the last one is valid.
+      // We can receive up to three setup packets in succession, but  only the last one is valid.
       _setup_packet[0] = (*rx_fifo);
       _setup_packet[1] = (*rx_fifo);
       break;
 
     case GRXSTS_PKTSTS_SETUPDONE:
-      // Setup packet done (Interrupt)
+      // Setup packet done:
+      // After popping this out, dwc2 asserts a DOEPINT_SETUP interrupt which is handled by handle_epout_irq()
       epout->doeptsiz |= (3 << DOEPTSIZ_STUPCNT_Pos);
       break;
 
@@ -959,7 +992,7 @@ static void handle_rxflvl_irq(uint8_t rhport) {
         tu_fifo_write_n_const_addr_full_words(xfer->ff, (const void*) (uintptr_t) rx_fifo, bcnt);
       } else {
         // Linear buffer
-        read_fifo_packet(rhport, xfer->buffer, bcnt);
+        dfifo_read_packet(rhport, xfer->buffer, bcnt);
 
         // Increment pointer to xfer data
         xfer->buffer += bcnt;
@@ -973,34 +1006,16 @@ static void handle_rxflvl_irq(uint8_t rhport) {
           ep0_pending[TUSB_DIR_OUT] = 0;
         }
       }
+      break;
     }
-      break;
 
-      // Out packet done (Interrupt)
     case GRXSTS_PKTSTS_OUTDONE:
-      // Occurred on STM32L47 with dwc2 version 3.10a but not found on other version like 2.80a or 3.30a
-      // May (or not) be 3.10a specific feature/bug or depending on MCU configuration
-      // XFRC complete is additionally generated when
-      // - setup packet is received
-      // - complete the data stage of control write is complete
-      if ((epnum == 0) && (bcnt == 0) && (dwc2->gsnpsid >= DWC2_CORE_REV_3_00a)) {
-        uint32_t doepint = epout->doepint;
-
-        if (doepint & (DOEPINT_STPKTRX | DOEPINT_OTEPSPR)) {
-          // skip this "no-data" transfer complete event
-          // Note: STPKTRX will be clear later by setup received handler
-          uint32_t clear_flags = DOEPINT_XFRC;
-
-          if (doepint & DOEPINT_OTEPSPR) clear_flags |= DOEPINT_OTEPSPR;
-
-          epout->doepint = clear_flags;
-
-          // TU_LOG(DWC2_DEBUG, "  FIX extra transfer complete on setup/data compete\r\n");
-        }
-      }
+      /* Out packet done
+         After this entry is popped from the receive FIFO, dwc2 asserts a Transfer Completed interrupt on
+         the specified OUT endpoint which will be handled by handle_epout_irq() */
       break;
 
-    default:    // Invalid
+    default:
       TU_BREAKPOINT();
       break;
   }
@@ -1012,37 +1027,68 @@ static void handle_epout_irq(uint8_t rhport) {
 
   // DAINT for a given EP clears when DOEPINTx is cleared.
   // OEPINT will be cleared when DAINT's out bits are cleared.
-  for (uint8_t n = 0; n < ep_count; n++) {
-    if (dwc2->daint & TU_BIT(DAINT_OEPINT_Pos + n)) {
-      dwc2_epout_t* epout = &dwc2->epout[n];
+  for (uint8_t epnum = 0; epnum < ep_count; epnum++) {
+    if (dwc2->daint & TU_BIT(DAINT_OEPINT_Pos + epnum)) {
+      dwc2_epout_t* epout = &dwc2->epout[epnum];
+      const uint32_t doepint = epout->doepint;
+      TU_ASSERT((epout->doepint & DOEPINT_AHBERR) == 0, );
 
-      uint32_t const doepint = epout->doepint;
-
-      // SETUP packet Setup Phase done.
-      if (doepint & DOEPINT_STUP) {
-        uint32_t clear_flag = DOEPINT_STUP;
-
-        // STPKTRX is only available for version from 3_00a
-        if ((doepint & DOEPINT_STPKTRX) && (dwc2->gsnpsid >= DWC2_CORE_REV_3_00a)) {
-          clear_flag |= DOEPINT_STPKTRX;
+      // Setup and/or STPKTRX/STSPHSRX (from 3.00a) can be set along with XFRC, and also set independently.
+      if (dwc2->gsnpsid >= DWC2_CORE_REV_3_00a) {
+        if (doepint & DOEPINT_STSPHSRX) {
+          // Status phase received for control write: In token received from Host
+          epout->doepint = DOEPINT_STSPHSRX;
         }
 
-        epout->doepint = clear_flag;
+        if (doepint & DOEPINT_STPKTRX) {
+          // New setup packet received, but wait for Setup done, since we can receive up to 3 setup consecutively
+          epout->doepint = DOEPINT_STPKTRX;
+        }
+      }
+
+      if (doepint & DOEPINT_SETUP) {
+        epout->doepint = DOEPINT_SETUP;
+
+        if(dma_enabled(dwc2)) {
+          dma_setup_prepare(rhport);
+        }
+
         dcd_event_setup_received(rhport, (uint8_t*) _setup_packet, true);
       }
 
       // OUT XFER complete
-      if (epout->doepint & DOEPINT_XFRC) {
+      if (doepint & DOEPINT_XFRC) {
         epout->doepint = DOEPINT_XFRC;
 
-        xfer_ctl_t* xfer = XFER_CTL_BASE(n, TUSB_DIR_OUT);
+        // only handle data skip if it is setup or status related
+        // Normal OUT transfer complete
+        if (!(doepint & (DOEPINT_SETUP | DOEPINT_STPKTRX | DOEPINT_STSPHSRX))) {
+          xfer_ctl_t* xfer = XFER_CTL_BASE(epnum, TUSB_DIR_OUT);
 
-        // EP0 can only handle one packet
-        if ((n == 0) && ep0_pending[TUSB_DIR_OUT]) {
-          // Schedule another packet to be received.
-          edpt_schedule_packets(rhport, n, TUSB_DIR_OUT, 1, ep0_pending[TUSB_DIR_OUT]);
-        } else {
-          dcd_event_xfer_complete(rhport, n, xfer->total_len, XFER_RESULT_SUCCESS, true);
+          if(dma_enabled(dwc2)) {
+            if ((epnum == 0) && ep0_pending[TUSB_DIR_OUT]) {
+              // EP0 can only handle one packet Schedule another packet to be received.
+              edpt_schedule_packets(rhport, epnum, TUSB_DIR_OUT, 1, ep0_pending[TUSB_DIR_OUT]);
+            } else {
+              // Fix packet length
+              uint16_t remain = (epout->doeptsiz & DOEPTSIZ_XFRSIZ_Msk) >> DOEPTSIZ_XFRSIZ_Pos;
+              xfer->total_len -= remain;
+              // this is ZLP, so prepare EP0 for next setup
+              if(epnum == 0 && xfer->total_len == 0) {
+                dma_setup_prepare(rhport);
+              }
+
+              dcd_event_xfer_complete(rhport, epnum, xfer->total_len, XFER_RESULT_SUCCESS, true);
+            }
+          } else {
+            // EP0 can only handle one packet
+            if ((epnum == 0) && ep0_pending[TUSB_DIR_OUT]) {
+              // Schedule another packet to be received.
+              edpt_schedule_packets(rhport, epnum, TUSB_DIR_OUT, 1, ep0_pending[TUSB_DIR_OUT]);
+            } else {
+              dcd_event_xfer_complete(rhport, epnum, xfer->total_len, XFER_RESULT_SUCCESS, true);
+            }
+          }
         }
       }
     }
@@ -1069,6 +1115,9 @@ static void handle_epin_irq(uint8_t rhport) {
           // Schedule another packet to be transmitted.
           edpt_schedule_packets(rhport, n, TUSB_DIR_IN, 1, ep0_pending[TUSB_DIR_IN]);
         } else {
+          if((n == 0) && dma_enabled(dwc2)) {
+            dma_setup_prepare(rhport);
+          }
           dcd_event_xfer_complete(rhport, n | TUSB_DIR_IN_MASK, xfer->total_len, XFER_RESULT_SUCCESS, true);
         }
       }
@@ -1098,7 +1147,7 @@ static void handle_epin_irq(uint8_t rhport) {
             volatile uint32_t* tx_fifo = dwc2->fifo[n];
             tu_fifo_read_n_const_addr_full_words(xfer->ff, (void*) (uintptr_t) tx_fifo, packet_size);
           } else {
-            write_fifo_packet(rhport, n, xfer->buffer, packet_size);
+            dfifo_write_packet(rhport, n, xfer->buffer, packet_size);
 
             // Increment pointer to xfer data
             xfer->buffer += packet_size;
@@ -1113,6 +1162,29 @@ static void handle_epin_irq(uint8_t rhport) {
     }
   }
 }
+
+/* Interrupt Hierarchy
+
+   DxEPMSK.XferComplMsk     DxEPINTn.XferCompl
+         |                       |
+         +---------- AND --------+
+                      |
+     DAINT.xEPnInt            DAINTMSK.xEPnMsk
+         |                       |
+         +---------- AND --------+
+                      |
+    GINTSTS.xEPInt         GINTMSK.xEPIntMsk
+         |                       |
+         +---------- AND --------+
+                      |
+             GAHBCFG.GblIntrMsk
+                      |
+                    IRQn
+
+  Note: when OTG_MULTI_PROC_INTRPT = 1, Device Each endpoint interrupt deachint/deachmsk/diepeachmsk/doepeachmsk
+  are combined to generate dedicated interrupt line for each endpoint.
+ */
+
 
 void dcd_int_handler(uint8_t rhport) {
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
@@ -1191,13 +1263,10 @@ void dcd_int_handler(uint8_t rhport) {
   // RxFIFO non-empty interrupt handling.
   if (int_status & GINTSTS_RXFLVL) {
     // RXFLVL bit is read-only
+    dwc2->gintmsk &= ~GINTMSK_RXFLVLM; // disable RXFLVL interrupt while reading
 
-    // Mask out RXFLVL while reading data from FIFO
-    dwc2->gintmsk &= ~GINTMSK_RXFLVLM;
-
-    // Loop until all available packets were handled
     do {
-      handle_rxflvl_irq(rhport);
+      handle_rxflvl_irq(rhport); // read all packets
     } while(dwc2->gintsts & GINTSTS_RXFLVL);
 
     dwc2->gintmsk |= GINTMSK_RXFLVLM;

--- a/src/portable/synopsys/dwc2/dwc2_bcm.h
+++ b/src/portable/synopsys/dwc2/dwc2_bcm.h
@@ -39,7 +39,7 @@
 
 static const dwc2_controller_t _dwc2_controller[] =
 {
-  { .reg_base = USB_OTG_GLOBAL_BASE, .irqnum = USB_IRQn, .ep_count = DWC2_EP_MAX, .ep_fifo_size = 4096 }
+  { .reg_base = USB_OTG_GLOBAL_BASE, .irqnum = USB_IRQn, .ep_count = DWC2_EP_MAX, .ep_fifo_size = 16384 }
 };
 
 #define dcache_clean(_addr, _size)              data_clean(_addr, _size)

--- a/src/portable/synopsys/dwc2/dwc2_esp32.h
+++ b/src/portable/synopsys/dwc2/dwc2_esp32.h
@@ -38,28 +38,41 @@
 #include "soc/periph_defs.h"
 #include "soc/usb_wrap_struct.h"
 
-#define DWC2_REG_BASE       0x60080000UL
-#define DWC2_EP_MAX         6             // USB_OUT_EP_NUM. TODO ESP32Sx only has 5 tx fifo (5 endpoint IN)
+#if TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3)
+#define DWC2_FS_REG_BASE   0x60080000UL
+#define DWC2_EP_MAX        7
 
 static const dwc2_controller_t _dwc2_controller[] = {
-  { .reg_base = DWC2_REG_BASE, .irqnum = 0, .ep_count = DWC2_EP_MAX, .ep_fifo_size = 1024 }
+  { .reg_base = DWC2_FS_REG_BASE, .irqnum = ETS_USB_INTR_SOURCE, .ep_count = 7, .ep_in_count = 5, .ep_fifo_size = 1024 }
 };
 
-static intr_handle_t usb_ih;
+#elif TU_CHECK_MCU(OPT_MCU_ESP32P4)
+#define DWC2_FS_REG_BASE   0x50040000UL
+#define DWC2_HS_REG_BASE   0x50000000UL
+#define DWC2_EP_MAX        16
+
+// On ESP32 for consistency we associate
+// - Port0 to OTG_FS, and Port1 to OTG_HS
+static const dwc2_controller_t _dwc2_controller[] = {
+{ .reg_base = DWC2_FS_REG_BASE, .irqnum = ETS_USB_OTG11_CH0_INTR_SOURCE, .ep_count = 7, .ep_in_count = 5, .ep_fifo_size = 1024 },
+{ .reg_base = DWC2_HS_REG_BASE, .irqnum = ETS_USB_OTG_INTR_SOURCE, .ep_count = 16, .ep_in_count = 8, .ep_fifo_size = 4096 }
+};
+#endif
+
+static intr_handle_t usb_ih[TU_ARRAY_SIZE(_dwc2_controller)];
 
 static void dcd_int_handler_wrap(void* arg) {
-  (void)arg;
-  dcd_int_handler(0);
+  const uint8_t rhport = (uint8_t)(uintptr_t) arg;
+  dcd_int_handler(rhport);
 }
 
 TU_ATTR_ALWAYS_INLINE static inline void dwc2_dcd_int_enable(uint8_t rhport) {
-  (void)rhport;
-  esp_intr_alloc(ETS_USB_INTR_SOURCE, ESP_INTR_FLAG_LOWMED, dcd_int_handler_wrap, NULL, &usb_ih);
+  esp_intr_alloc(_dwc2_controller[rhport].irqnum, ESP_INTR_FLAG_LOWMED,
+                 dcd_int_handler_wrap, (void*)(uintptr_t) rhport, &usb_ih[rhport]);
 }
 
 TU_ATTR_ALWAYS_INLINE static inline void dwc2_dcd_int_disable(uint8_t rhport) {
-  (void)rhport;
-  esp_intr_free(usb_ih);
+  esp_intr_free(usb_ih[rhport]);
 }
 
 TU_ATTR_ALWAYS_INLINE static inline void dwc2_remote_wakeup_delay(void) {
@@ -70,7 +83,6 @@ TU_ATTR_ALWAYS_INLINE static inline void dwc2_remote_wakeup_delay(void) {
 TU_ATTR_ALWAYS_INLINE static inline void dwc2_phy_init(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
   (void)dwc2;
   (void)hs_phy_type;
-
   // nothing to do
 }
 
@@ -78,7 +90,6 @@ TU_ATTR_ALWAYS_INLINE static inline void dwc2_phy_init(dwc2_regs_t* dwc2, uint8_
 TU_ATTR_ALWAYS_INLINE static inline void dwc2_phy_update(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
   (void)dwc2;
   (void)hs_phy_type;
-
   // nothing to do
 }
 

--- a/src/portable/synopsys/dwc2/dwc2_stm32.h
+++ b/src/portable/synopsys/dwc2/dwc2_stm32.h
@@ -142,7 +142,7 @@ TU_ATTR_ALWAYS_INLINE static inline void dwc2_remote_wakeup_delay(void) {
 // - dwc2 3.30a (H5) use USB_HS_PHYC
 // - dwc2 4.11a (U5) use femtoPHY
 static inline void dwc2_phy_init(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
-  if (hs_phy_type == HS_PHY_TYPE_NONE) {
+  if (hs_phy_type == GHWCFG2_HSPHY_NOT_SUPPORTED) {
     // Enable on-chip FS PHY
     dwc2->stm32_gccfg |= STM32_GCCFG_PWRDWN;
 
@@ -175,7 +175,7 @@ static inline void dwc2_phy_init(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
 #endif
 
     // Enable on-chip HS PHY
-    if (hs_phy_type == HS_PHY_TYPE_UTMI || hs_phy_type == HS_PHY_TYPE_UTMI_ULPI) {
+    if (hs_phy_type == GHWCFG2_HSPHY_UTMI || hs_phy_type == GHWCFG2_HSPHY_UTMI_ULPI) {
       #ifdef USB_HS_PHYC
       // Enable UTMI HS PHY
       dwc2->stm32_gccfg |= STM32_GCCFG_PHYHSEN;
@@ -218,7 +218,7 @@ static inline void dwc2_phy_init(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
 // MCU specific PHY update, it is called AFTER init() and core reset
 static inline void dwc2_phy_update(dwc2_regs_t* dwc2, uint8_t hs_phy_type) {
   // used to set turnaround time for fullspeed, nothing to do in highspeed mode
-  if (hs_phy_type == HS_PHY_TYPE_NONE) {
+  if (hs_phy_type == GHWCFG2_HSPHY_NOT_SUPPORTED) {
     // Turnaround timeout depends on the AHB clock dictated by STM32 Reference Manual
     uint32_t turnaround;
 

--- a/src/portable/synopsys/dwc2/dwc2_type.h
+++ b/src/portable/synopsys/dwc2/dwc2_type.h
@@ -46,6 +46,7 @@ typedef struct
   uintptr_t reg_base;
   uint32_t  irqnum;
   uint8_t   ep_count;
+  uint8_t   ep_in_count;
   uint32_t  ep_fifo_size;
 }dwc2_controller_t;
 
@@ -86,86 +87,222 @@ typedef struct
 #endif
 
 enum {
-  HS_PHY_TYPE_NONE = 0  , // not supported
-  HS_PHY_TYPE_UTMI      , // internal PHY (mostly)
-  HS_PHY_TYPE_ULPI      , // external PHY
-  HS_PHY_TYPE_UTMI_ULPI ,
+  GHWCFG2_OPMODE_HNP_SRP         = 0,
+  GHWCFG2_OPMODE_SRP             = 1,
+  GHWCFG2_OPMODE_NON_HNP_NON_SRP = 2,
+  GHWCFG2_OPMODE_SRP_DEVICE      = 3,
+  GHWCFFG2_OPMODE_NON_OTG_DEVICE = 4,
+  GHWCFG2_OPMODE_SRP_HOST        = 5,
+  GHWCFG2_OPMODE_NON_OTG_HOST    = 6,
+};
+enum {
+  GHWCFG2_ARCH_SLAVE_ONLY   = 0,
+  GHWCFG2_ARCH_EXTERNAL_DMA = 1,
+  GHWCFG2_ARCH_INTERNAL_DMA = 2,
 };
 
 enum {
-  FS_PHY_TYPE_NONE = 0,  // not supported
-  FS_PHY_TYPE_DEDICATED,
-  FS_PHY_TYPE_UTMI,
-  FS_PHY_TYPE_ULPI,
+  GHWCFG2_HSPHY_NOT_SUPPORTED = 0,
+  GHWCFG2_HSPHY_UTMI          = 1, // internal PHY (mostly)
+  GHWCFG2_HSPHY_ULPI          = 2, // external PHY (mostly)
+  GHWCFG2_HSPHY_UTMI_ULPI     = 3, // both
+
 };
 
-typedef struct TU_ATTR_PACKED
-{
-  uint32_t op_mode                  : 3; // 0: HNP and SRP | 1: SRP | 2: non-HNP, non-SRP
-  uint32_t arch                     : 2; // 0: slave-only | 1: External DMA | 2: Internal DMA | 3: others
-  uint32_t point2point              : 1; // 0: support hub and split | 1: no hub, no split
-  uint32_t hs_phy_type              : 2; // 0: not supported | 1: UTMI+ | 2: ULPI | 3: UTMI+ and ULPI
-  uint32_t fs_phy_type              : 2; // 0: not supported | 1: dedicated | 2: UTMI+ | 3: ULPI
-  uint32_t num_dev_ep               : 4; // Number of device endpoints (not including EP0)
-  uint32_t num_host_ch              : 4; // Number of host channel
-  uint32_t period_channel_support   : 1; // Support Periodic OUT Host Channel
-  uint32_t enable_dynamic_fifo      : 1; // Dynamic FIFO Sizing Enabled
-  uint32_t mul_cpu_int              : 1; // Multi-Processor Interrupt Enabled
-  uint32_t reserved21               : 1;
-  uint32_t nperiod_tx_q_depth       : 2; // Non-periodic request queue depth: 0 = 2.  1 = 4, 2 = 8
-  uint32_t host_period_tx_q_depth   : 2; // Host periodic request queue depth: 0 = 2.  1 = 4, 2 = 8
-  uint32_t dev_token_q_depth        : 5; // Device IN token sequence learning queue depth: 0-30
-  uint32_t otg_enable_ic_usb        : 1; // IC_USB mode specified for mode of operation
-} dwc2_ghwcfg2_t;
+enum {
+  GHWCFG2_FSPHY_NOT_SUPPORTED = 0,
+  GHWCFG2_FSPHY_DEDICATED     = 1, // have dedicated FS PHY
+  GHWCFG2_FSPHY_UTMI          = 2, // shared with UTMI+
+  GHWCFG2_FSPHY_ULPI          = 3, // shared with ULPI
+};
 
+enum {
+  GHWCFFG4_PHY_DATA_WIDTH_8    = 0,
+  GHWCFFG4_PHY_DATA_WIDTH_16   = 1,
+  GHWCFFG4_PHY_DATA_WIDTH_8_16 = 2, // software selectable
+};
+
+//--------------------------------------------------------------------
+// Register bitfield definitions
+//--------------------------------------------------------------------
+typedef struct TU_ATTR_PACKED {
+  uint32_t ses_req_scs           : 1; //  0 Session request success
+  uint32_t ses_req               : 1; //  1 Session request
+  uint32_t vbval_ov_en           : 1; //  2 VBUS valid override enable
+  uint32_t vbval_ov_val          : 1; //  3 VBUS valid override value
+  uint32_t aval_ov_en            : 1; //  4 A-peripheral session valid override enable
+  uint32_t aval_ov_al            : 1; //  5 A-peripheral session valid override value
+  uint32_t bval_ov_en            : 1; //  6 B-peripheral session valid override enable
+  uint32_t bval_ov_val           : 1; //  7 B-peripheral session valid override value
+  uint32_t hng_scs               : 1; //  8 Host negotiation success
+  uint32_t hnp_rq                : 1; //  9 HNP (host negotiation protocol) request
+  uint32_t host_set_hnp_en       : 1; // 10 Host set HNP enable
+  uint32_t dev_hnp_en            : 1; // 11 Device HNP enabled
+  uint32_t embedded_host_en      : 1; // 12 Embedded host enable
+  uint32_t rsv13_14              : 2; // 13.14 Reserved
+  uint32_t dbnc_filter_bypass    : 1; // 15 Debounce filter bypass
+  uint32_t cid_status            : 1; // 16 Connector ID status
+  uint32_t dbnc_done             : 1; // 17 Debounce done
+  uint32_t ases_valid            : 1; // 18 A-session valid
+  uint32_t bses_valid            : 1; // 19 B-session valid
+  uint32_t otg_ver               : 1; // 20 OTG version 0: v1.3, 1: v2.0
+  uint32_t current_mode          : 1; // 21 Current mode of operation 0: device, 1: host
+  uint32_t mult_val_id_bc        : 5; // 22..26 Multi-valued input pin ID battery charger
+  uint32_t chirp_en              : 1; // 27 Chirp detection enable
+  uint32_t rsv28_30              : 3; // 28.30: Reserved
+  uint32_t test_mode_corr_eusb2  : 1; // 31 Test mode control for eUSB2 PHY
+} dwc2_gotgctl_t;
+TU_VERIFY_STATIC(sizeof(dwc2_gotgctl_t) == 4, "incorrect size");
+
+typedef struct TU_ATTR_PACKED {
+  uint32_t rsv0_1                : 2; //  0..1  Reserved
+  uint32_t ses_end_det           : 1; //  2     Session end detected
+  uint32_t rsv3_7                : 5; //  3..7  Reserved
+  uint32_t srs_status_change     : 1; //  8     Session request success status change
+  uint32_t hns_status_change     : 1; //  9     Host negotiation success status change
+  uint32_t rsv10_16              : 7; // 10..16 Reserved
+  uint32_t hng_det               : 1; // 17     Host negotiation detected
+  uint32_t adev_timeout_change   : 1; // 18     A-device timeout change
+  uint32_t dbnc_done             : 1; // 19     Debounce done
+  uint32_t mult_val_lp_change    : 1; // 20     Multi-valued input pin change
+  uint32_t rsv21_31              :11; // 21..31 Reserved
+} dwc2_gotgint_t;
+TU_VERIFY_STATIC(sizeof(dwc2_gotgint_t) == 4, "incorrect size");
+
+typedef struct TU_ATTR_PACKED {
+  uint32_t gintmask              :  1; //  0 Global interrupt mask
+  uint32_t hbst_len              :  4; //  1..4 Burst length/type
+  uint32_t dma_en                :  1; //  5 DMA enable
+  uint32_t rsv6                  :  1; //  6 Reserved
+  uint32_t nptxf_empty_lvl       :  1; //  7 Non-periodic Tx FIFO empty level
+  uint32_t ptxf_empty_lvl        :  1; //  8 Periodic Tx FIFO empty level
+  uint32_t rsv9_20               : 12; //  9.20: Reserved
+  uint32_t remote_mem_support    :  1; // 21 Remote memory support
+  uint32_t notify_all_dma_write  :  1; // 22 Notify all DMA writes
+  uint32_t ahb_single            :  1; // 23 AHB single
+  uint32_t inv_desc_endian       :  1; // 24 Inverse descriptor endian
+  uint32_t rsv25_31              :  7; // 25..31 Reserved
+} dwc2_gahbcfg_t;
+TU_VERIFY_STATIC(sizeof(dwc2_gahbcfg_t) == 4, "incorrect size");
+
+typedef struct TU_ATTR_PACKED {
+  uint32_t timeout_cal             :  3; /* 0..2 Timeout calibration.
+    The USB standard timeout value for high-speed operation is 736 to 816 (inclusive) bit times. The USB standard
+    timeout value for full- speed operation is 16 to 18 (inclusive) bit times. The application must program this field
+    based on the speed of enumeration. The number of bit times added per PHY clock are as follows:
+    - High-speed: PHY clock One 30-MHz = 16 bit times, One 60-MHz = 8 bit times
+    - Full-speed: PHY clock One 30-MHz = 0.4 bit times, One 60-MHz = 0.2 bit times, One 48-MHz = 0.25 bit times */
+  uint32_t phy_if                  : 1; // 3 PHY interface. 0: 8 bits, 1: 16 bits
+  uint32_t ulpi_utmi_sel           : 1; // 4 ULPI/UTMI select. 0: UTMI+, 1: ULPI
+  uint32_t fs_intf_sel             : 1; // 5 Fullspeed serial interface select. 0: 6-pin, 1: 3-pin
+  uint32_t phy_sel                 : 1; // 6 HS/FS PHY selection. 0: HS UTMI+ or ULPI, 1: FS serial transceiver
+  uint32_t ddr_sel                 : 1; // 7 ULPI DDR select. 0: Single data rate 8-bit, 1: Double data rate 4-bit
+  uint32_t srp_capable             : 1; // 8 SRP-capable
+  uint32_t hnp_capable             : 1; // 9 HNP-capable
+  uint32_t turnaround_time         : 4; // 10..13 Turnaround time. 9: 8-bit UTMI+, 5: 16-bit UTMI+
+  uint32_t rsv14                   : 1; // 14 Reserved
+  uint32_t phy_low_power_clk_sel   : 1; /* 15 PHY low-power clock select either 480-MHz or 48-MHz (low-power) PHY mode.
+    In FS/LS modes, the PHY can usually operate on a 48-MHz clock to save power. This bit is valid only for UTMI+ PHYs.
+    - 0: 480 Mhz internal PLL: the UTMI interface operates at either 60 MHz (8 bit) or 30 MHz (16-bit)
+    - 1 48 Mhz external clock: the UTMI interface operates at 48 MHz in FS mode and at either 48 or 6 MHz in LS mode */
+  uint32_t otg_i2c_sel             : 1; // 16 OTG I2C interface select. 0: UTMI-FS, 1: I2C for OTG signals
+  uint32_t ulpi_fsls               : 1; /* 17 ULPI FS/LS select. 0: ULPI, 1: ULPI FS/LS.
+                                             valid only when the FS serial transceiver is selected on the ULPI PHY. */
+  uint32_t ulpi_auto_resume        : 1; // 18 ULPI Auto-resume
+  uint32_t ulpi_clk_sus_m          : 1; // 19 ULPI Clock SuspendM
+  uint32_t ulpi_ext_vbus_drv       : 1; // 20 ULPI External VBUS Drive
+  uint32_t ulpi_int_vbus_indicator : 1; // 21 ULPI Internal VBUS Indicator
+  uint32_t term_sel_dl_pulse       : 1; // 22 TermSel DLine pulsing
+  uint32_t indicator_complement    : 1; // 23 Indicator complement
+  uint32_t indicator_pass_through  : 1; // 24 Indicator pass through
+  uint32_t ulpi_if_protect_disable : 1; // 25 ULPI interface protect disable
+  uint32_t ic_usb_capable          : 1; // 26 IC_USB Capable
+  uint32_t ic_usb_traf_ctl         : 1; // 27 IC_USB Traffic Control
+  uint32_t tx_end_delay            : 1; // 28 TX end delay
+  uint32_t force_host_mode         : 1; // 29 Force host mode
+  uint32_t force_dev_mode          : 1; // 30 Force device mode
+  uint32_t corrupt_tx_pkt          : 1; // 31 Corrupt Tx packet. 0: normal, 1: debug
+} dwc2_gusbcfg_t;
+TU_VERIFY_STATIC(sizeof(dwc2_gusbcfg_t) == 4, "incorrect size");
+
+typedef struct TU_ATTR_PACKED {
+  uint32_t core_soft_rst          : 1; // 0 Core Soft Reset
+  uint32_t piufs_soft_rst         : 1; // 1 PIU FS Dedicated Controller Soft Reset
+  uint32_t frame_counter_rst      : 1; // 2 Frame Counter Reset (host)
+  uint32_t intoken_q_flush        : 1; // 3 IN Token Queue Flush
+  uint32_t rx_fifo_flush          : 1; // 4 RX FIFO Flush
+  uint32_t tx_fifo_flush          : 1; // 5 TX FIFO Flush
+  uint32_t tx_fifo_num            : 5; // 6..10 TX FIFO Number
+  uint32_t rsv11_28               :18; // 11..28 Reserved
+  uint32_t core_soft_rst_done     : 1; // 29 Core Soft Reset Done, from v4.20a
+  uint32_t dma_req                : 1; // 30 DMA Request
+  uint32_t ahb_idle               : 1; // 31 AHB Idle
+} dwc2_grstctl_t;
+TU_VERIFY_STATIC(sizeof(dwc2_grstctl_t) == 4, "incorrect size");
+
+typedef struct TU_ATTR_PACKED {
+  uint32_t op_mode                : 3; // 0..2 HNP/SRP Host/Device/OTG mode
+  uint32_t arch                   : 2; // 3..4 Slave/External/Internal DMA
+  uint32_t point2point            : 1; // 5 0: support hub and split | 1: no hub, no split
+  uint32_t hs_phy_type            : 2; // 6..7 0: not supported | 1: UTMI+ | 2: ULPI | 3: UTMI+ and ULPI
+  uint32_t fs_phy_type            : 2; // 8..9 0: not supported | 1: dedicated | 2: UTMI+ | 3: ULPI
+  uint32_t num_dev_ep             : 4; // 10..13 Number of device endpoints (excluding EP0)
+  uint32_t num_host_ch            : 4; // 14..17 Number of host channel (excluding control)
+  uint32_t period_channel_support : 1; // 18 Support Periodic OUT Host Channel
+  uint32_t enable_dynamic_fifo    : 1; // 19 Dynamic FIFO Sizing Enabled
+  uint32_t mul_proc_intrpt        : 1; // 20 Multi-Processor Interrupt enabled (OTG_MULTI_PROC_INTRPT)
+  uint32_t reserved21             : 1; // 21 reserved
+  uint32_t nptx_q_depth           : 2; // 22..23 Non-periodic request queue depth: 0 = 2.  1 = 4, 2 = 8
+  uint32_t ptx_q_depth            : 2; // 24..25 Host periodic request queue depth: 0 = 2.  1 = 4, 2 = 8
+  uint32_t token_q_depth          : 5; // 26..30 Device IN token sequence learning queue depth: 0-30
+  uint32_t otg_enable_ic_usb      : 1; // 31 IC_USB mode specified for mode of operation
+} dwc2_ghwcfg2_t;
 TU_VERIFY_STATIC(sizeof(dwc2_ghwcfg2_t) == 4, "incorrect size");
 
-typedef struct TU_ATTR_PACKED
-{
-  uint32_t xfer_size_width          : 4;  // Transfer size counter in bits = 11 + n (max 19 bits)
-  uint32_t packet_size_width        : 3;  // Packet size counter in bits = 4 + n (max 10 bits)
-  uint32_t otg_enable               : 1;  // 1 is OTG capable
-  uint32_t i2c_enable               : 1;  // I2C interface is available
-  uint32_t vendor_ctrl_itf          : 1;  // Vendor control interface is available
-  uint32_t optional_feature_removed : 1;  // remove User ID, GPIO, SOF toggle & counter
-  uint32_t synch_reset              : 1;  // 0: async reset | 1: synch reset
-  uint32_t otg_adp_support          : 1;  // ADP logic is present along with HSOTG controller
-  uint32_t otg_enable_hsic          : 1;  // 1: HSIC-capable with shared UTMI PHY interface | 0: non-HSIC
-  uint32_t battery_charger_support  : 1;  // support battery charger
-  uint32_t lpm_mode                 : 1;  // LPC mode
-  uint32_t total_fifo_size          : 16; // DFIFO depth value in terms of 32-bit words
+typedef struct TU_ATTR_PACKED {
+  uint32_t xfer_size_width          : 4;  // 0..3 Transfer size counter in bits = 11 + n (max 19 bits)
+  uint32_t packet_size_width        : 3;  // 4..6 Packet size counter in bits = 4 + n (max 10 bits)
+  uint32_t otg_enable               : 1;  // 7 OTG capable
+  uint32_t i2c_enable               : 1;  // 8 I2C interface is available
+  uint32_t vendor_ctrl_itf          : 1;  // 9 Vendor control interface is available
+  uint32_t optional_feature_removed : 1;  // 10 remove User ID, GPIO, SOF toggle & counter to save gate count
+  uint32_t synch_reset              : 1;  // 11 0: async reset | 1: synch reset
+  uint32_t otg_adp_support          : 1;  // 12 ADP logic is present along with HSOTG controller
+  uint32_t otg_enable_hsic          : 1;  // 13 1: HSIC-capable with shared UTMI PHY interface | 0: non-HSIC
+  uint32_t battery_charger_support  : 1;  // s14 upport battery charger
+  uint32_t lpm_mode                 : 1;  // 15 LPM mode
+  uint32_t dfifo_depth              : 16; // DFIFO depth - EP_LOC_CNT in terms of 32-bit words
 }dwc2_ghwcfg3_t;
-
 TU_VERIFY_STATIC(sizeof(dwc2_ghwcfg3_t) == 4, "incorrect size");
 
-typedef struct TU_ATTR_PACKED
-{
-  uint32_t num_dev_period_in_ep       : 4; // Number of Device Periodic IN Endpoints
-  uint32_t power_optimized            : 1; // Partial Power Down Enabled
-  uint32_t ahb_freq_min               : 1; // 1: minimum of AHB frequency is less than 60 MHz
-  uint32_t hibernation                : 1; // Hibernation feature is enabled
-  uint32_t reserved7                  : 3;
-  uint32_t service_interval_mode      : 1; // Service Interval supported
-  uint32_t ipg_isoc_en                : 1; // IPG ISOC supported
-  uint32_t acg_enable                 : 1; // ACG enabled
-  uint32_t reserved13                 : 1;
-  uint32_t utmi_phy_data_width        : 2; // 0: 8 bits | 1: 16 bits | 2: 8/16 software selectable
-  uint32_t dev_ctrl_ep_num            : 4; // Number of Device control endpoints in addition to EP0
-  uint32_t iddg_filter_enabled        : 1;
-  uint32_t vbus_valid_filter_enabled  : 1;
-  uint32_t a_valid_filter_enabled     : 1;
-  uint32_t b_valid_filter_enabled     : 1;
-  uint32_t dedicated_fifos            : 1; // Dedicated tx fifo for device IN Endpoint is enabled
-  uint32_t num_dev_in_eps             : 4; // Number of Device IN Endpoints including EP0
-  uint32_t dma_desc_enable            : 1; // scatter/gather DMA configuration
-  uint32_t dma_dynamic                : 1; // Dynamic scatter/gather DMA
+typedef struct TU_ATTR_PACKED {
+  uint32_t num_dev_period_in_ep     : 4; // 0..3 Number of Device Periodic IN Endpoints
+  uint32_t partial_powerdown        : 1; // 4 Partial Power Down Enabled
+  uint32_t ahb_freq_min             : 1; // 5 1: minimum of AHB frequency is less than 60 MHz
+  uint32_t hibernation              : 1; // 6 Hibernation feature is enabled
+  uint32_t extended_hibernation     : 1; // 7 Extended Hibernation feature is enabled
+  uint32_t reserved8                : 1; // 8 Reserved
+  uint32_t enhanced_lpm_support1    : 1; // 9 Enhanced LPM Support1
+  uint32_t service_interval_flow    : 1; // 10 Service Interval flow is supported
+  uint32_t ipg_isoc_support         : 1; // 11 Interpacket GAP ISO OUT worst-case is supported
+  uint32_t acg_support              : 1; // 12 Active clock gating is supported
+  uint32_t enhanced_lpm_support     : 1; // 13 Enhanced LPM Support
+  uint32_t phy_data_width           : 2; // 14..15 0: 8 bits | 1: 16 bits | 2: 8/16 software selectable
+  uint32_t ctrl_ep_num              : 4; // 16..19 Number of Device control endpoints in addition to EP0
+  uint32_t iddg_filter              : 1; // 20 IDDG Filter Enabled
+  uint32_t vbus_valid_filter        : 1; // 21 VBUS Valid Filter Enabled
+  uint32_t a_valid_filter           : 1; // 22 A Valid Filter Enabled
+  uint32_t b_valid_filter           : 1; // 23 B Valid Filter Enabled
+  uint32_t session_end_filter       : 1; // 24 Session End Filter Enabled
+  uint32_t dedicated_fifos          : 1; // 25 Dedicated tx fifo for device IN Endpoint
+  uint32_t num_dev_in_eps           : 4; // 26..29 Number of Device IN Endpoints including EP0
+  uint32_t dma_desc_enabled         : 1; // scatter/gather DMA configuration enabled
+  uint32_t dma_desc_dynamic         : 1; // Dynamic scatter/gather DMA
 }dwc2_ghwcfg4_t;
-
 TU_VERIFY_STATIC(sizeof(dwc2_ghwcfg4_t) == 4, "incorrect size");
 
 // Host Channel
-typedef struct
-{
+typedef struct {
   volatile uint32_t hcchar;           // 500 + 20*ch Host Channel Characteristics
   volatile uint32_t hcsplt;           // 504 + 20*ch Host Channel Split Control
   volatile uint32_t hcint;            // 508 + 20*ch Host Channel Interrupt
@@ -177,8 +314,7 @@ typedef struct
 } dwc2_channel_t;
 
 // Endpoint IN
-typedef struct
-{
+typedef struct {
   volatile uint32_t diepctl;          // 900 + 20*ep Device IN Endpoint Control
            uint32_t reserved04;       // 904
   volatile uint32_t diepint;          // 908 + 20*ep Device IN Endpoint Interrupt
@@ -190,8 +326,7 @@ typedef struct
 } dwc2_epin_t;
 
 // Endpoint OUT
-typedef struct
-{
+typedef struct {
   volatile uint32_t doepctl;          // B00 + 20*ep Device OUT Endpoint Control
            uint32_t reserved04;       // B04
   volatile uint32_t doepint;          // B08 + 20*ep Device OUT Endpoint Interrupt
@@ -201,105 +336,141 @@ typedef struct
            uint32_t reserved18[2];    // B18..B1C
 } dwc2_epout_t;
 
-typedef struct
-{
-  //------------- Core Global -------------//
-  volatile uint32_t gotgctl;          // 000 OTG Control and Status
-  volatile uint32_t gotgint;          // 004 OTG Interrupt
-  volatile uint32_t gahbcfg;          // 008 AHB Configuration
-  volatile uint32_t gusbcfg;          // 00c USB Configuration
-  volatile uint32_t grstctl;          // 010 Reset
-  volatile uint32_t gintsts;          // 014 Interrupt
-  volatile uint32_t gintmsk;          // 018 Interrupt Mask
-  volatile uint32_t grxstsr;          // 01c Receive Status Debug Read
-  volatile uint32_t grxstsp;          // 020 Receive Status Read/Pop
-  volatile uint32_t grxfsiz;          // 024 Receive FIFO Size
-union {
-  volatile uint32_t dieptxf0;         // 028 EP0 Tx FIFO Size
-  volatile uint32_t gnptxfsiz;        // 028 Non-periodic Transmit FIFO Size
-};
-  volatile uint32_t gnptxsts;         // 02c Non-periodic Transmit FIFO/Queue Status
-  volatile uint32_t gi2cctl;          // 030 I2C Address
-  volatile uint32_t gpvndctl;         // 034 PHY Vendor Control
-union {
-  volatile uint32_t ggpio;            // 038 General Purpose IO
-  volatile uint32_t stm32_gccfg;      // 038 STM32 General Core Configuration
-};
-  volatile uint32_t guid;             // 03C User (Application programmable) ID
-  volatile uint32_t gsnpsid;          // 040 Synopsys ID + Release version
-  volatile uint32_t ghwcfg1;          // 044 User Hardware Configuration1: endpoint dir (2 bit per ep)
-union {
-  volatile uint32_t ghwcfg2;          // 048 User Hardware Configuration2
-  dwc2_ghwcfg2_t    ghwcfg2_bm;
-};
-union {
-  volatile uint32_t ghwcfg3;          // 04C User Hardware Configuration3
-  dwc2_ghwcfg3_t    ghwcfg3_bm;
-};
-union {
-  volatile uint32_t ghwcfg4;          // 050 User Hardware Configuration4
-  dwc2_ghwcfg4_t    ghwcfg4_bm;
-};
-  volatile uint32_t glpmcfg;          // 054 Core LPM Configuration
-  volatile uint32_t gpwrdn;           // 058 Power Down
-  volatile uint32_t gdfifocfg;        // 05C DFIFO Software Configuration
-  volatile uint32_t gadpctl;          // 060 ADP Timer, Control and Status
-           uint32_t reserved64[39];   // 064..0FF
-  volatile uint32_t hptxfsiz;         // 100 Host Periodic Tx FIFO Size
-  volatile uint32_t dieptxf[15];      // 104..13C Device Periodic Transmit FIFO Size
-           uint32_t reserved140[176]; // 140..3FF
+typedef struct {
+  union {
+    volatile uint32_t diepctl;
+    volatile uint32_t doepctl;
+    volatile uint32_t ctl;
+  };
+  uint32_t rsv04;
+  union {
+    volatile uint32_t diepint;
+    volatile uint32_t doepint;
+  };
+  uint32_t rsv0c;
+  union {
+    volatile uint32_t dieptsiz;
+    volatile uint32_t doeptsiz;
+  };
+  union {
+    volatile uint32_t diepdma;
+    volatile uint32_t doepdma;
+  };
+  volatile uint32_t dtxfsts;
+  uint32_t rsv1c;
+}dwc2_dep_t;
 
-  //------------- Host -------------//
-  volatile uint32_t hcfg;             // 400 Host Configuration
-  volatile uint32_t hfir;             // 404 Host Frame Interval
-  volatile uint32_t hfnum;            // 408 Host Frame Number / Frame Remaining
-           uint32_t reserved40c;      // 40C
-  volatile uint32_t hptxsts;          // 410 Host Periodic TX FIFO / Queue Status
-  volatile uint32_t haint;            // 414 Host All Channels Interrupt
-  volatile uint32_t haintmsk;         // 418 Host All Channels Interrupt Mask
-  volatile uint32_t hflbaddr;         // 41C Host Frame List Base Address
-           uint32_t reserved420[8];   // 420..43F
-  volatile uint32_t hprt;             // 440 Host Port Control and Status
-           uint32_t reserved444[47];  // 444..4FF
+TU_VERIFY_STATIC(sizeof(dwc2_dep_t) == 0x20, "incorrect size");
 
-  //------------- Host Channel -------------//
-  dwc2_channel_t    channel[16];      // 500..6FF Host Channels 0-15
-           uint32_t reserved700[64];  // 700..7FF
+//--------------------------------------------------------------------
+// CSR Register Map
+//--------------------------------------------------------------------
+typedef struct {
+    //------------- Core Global -------------//
+    volatile uint32_t gotgctl;          // 000 OTG Control and Status
+    volatile uint32_t gotgint;          // 004 OTG Interrupt
+    volatile uint32_t gahbcfg;          // 008 AHB Configuration
+    volatile uint32_t gusbcfg;          // 00c USB Configuration
+    volatile uint32_t grstctl;          // 010 Reset
+    volatile uint32_t gintsts;          // 014 Interrupt
+    volatile uint32_t gintmsk;          // 018 Interrupt Mask
+    volatile uint32_t grxstsr;          // 01c Receive Status Debug Read
+    volatile uint32_t grxstsp;          // 020 Receive Status Read/Pop
+    volatile uint32_t grxfsiz;          // 024 Receive FIFO Size
+  union {
+    volatile uint32_t dieptxf0;         // 028 EP0 Tx FIFO Size
+    volatile uint32_t gnptxfsiz;        // 028 Non-periodic Transmit FIFO Size
+  };
+    volatile uint32_t gnptxsts;         // 02c Non-periodic Transmit FIFO/Queue Status
+    volatile uint32_t gi2cctl;          // 030 I2C Address
+    volatile uint32_t gpvndctl;         // 034 PHY Vendor Control
+  union {
+    volatile uint32_t ggpio;            // 038 General Purpose IO
+    volatile uint32_t stm32_gccfg;      // 038 STM32 General Core Configuration
+  };
+    volatile uint32_t guid;             // 03C User (Application programmable) ID
+    volatile uint32_t gsnpsid;          // 040 Synopsys ID + Release version
+    volatile uint32_t ghwcfg1;          // 044 User Hardware Configuration1: endpoint dir (2 bit per ep)
+  union {
+    volatile uint32_t ghwcfg2;          // 048 User Hardware Configuration2
+    volatile dwc2_ghwcfg2_t ghwcfg2_bm;
+  };
+  union {
+    volatile uint32_t ghwcfg3;          // 04C User Hardware Configuration3
+    volatile dwc2_ghwcfg3_t ghwcfg3_bm;
+  };
+  union {
+    volatile uint32_t ghwcfg4;          // 050 User Hardware Configuration4
+    volatile dwc2_ghwcfg4_t ghwcfg4_bm;
+  };
+    volatile uint32_t glpmcfg;          // 054 Core LPM Configuration
+    volatile uint32_t gpwrdn;           // 058 Power Down
+    volatile uint32_t gdfifocfg;        // 05C DFIFO Software Configuration
+    volatile uint32_t gadpctl;          // 060 ADP Timer, Control and Status
+             uint32_t reserved64[39];   // 064..0FF
+    volatile uint32_t hptxfsiz;         // 100 Host Periodic Tx FIFO Size
+    volatile uint32_t dieptxf[15];      // 104..13C Device Periodic Transmit FIFO Size
+             uint32_t reserved140[176]; // 140..3FF
 
- //------------- Device -------------//
-  volatile uint32_t dcfg;             // 800 Device Configuration
-  volatile uint32_t dctl;             // 804 Device Control
-  volatile uint32_t dsts;             // 808 Device Status (RO)
-           uint32_t reserved80c;      // 80C
-  volatile uint32_t diepmsk;          // 810 Device IN Endpoint Interrupt Mask
-  volatile uint32_t doepmsk;          // 814 Device OUT Endpoint Interrupt Mask
-  volatile uint32_t daint;            // 818 Device All Endpoints Interrupt
-  volatile uint32_t daintmsk;         // 81C Device All Endpoints Interrupt Mask
-  volatile uint32_t dtknqr1;          // 820 Device IN token sequence learning queue read1
-  volatile uint32_t dtknqr2;          // 824 Device IN token sequence learning queue read2
-  volatile uint32_t dvbusdis;         // 828 Device VBUS Discharge Time
-  volatile uint32_t dvbuspulse;       // 82C Device VBUS Pulsing Time
-  volatile uint32_t dthrctl;          // 830 Device threshold Control
-  volatile uint32_t diepempmsk;       // 834 Device IN Endpoint FIFO Empty Interrupt Mask
-  volatile uint32_t deachint;         // 838 Device Each Endpoint Interrupt
-  volatile uint32_t deachmsk;         // 83C Device Each Endpoint Interrupt msk
-  volatile uint32_t diepeachmsk[16];  // 840..87C Device Each IN Endpoint mask
-  volatile uint32_t doepeachmsk[16];  // 880..8BF Device Each OUT Endpoint mask
-           uint32_t reserved8c0[16];  // 8C0..8FF
+    //------------ Host -------------//
+    volatile uint32_t hcfg;             // 400 Host Configuration
+    volatile uint32_t hfir;             // 404 Host Frame Interval
+    volatile uint32_t hfnum;            // 408 Host Frame Number / Frame Remaining
+             uint32_t reserved40c;      // 40C
+    volatile uint32_t hptxsts;          // 410 Host Periodic TX FIFO / Queue Status
+    volatile uint32_t haint;            // 414 Host All Channels Interrupt
+    volatile uint32_t haintmsk;         // 418 Host All Channels Interrupt Mask
+    volatile uint32_t hflbaddr;         // 41C Host Frame List Base Address
+             uint32_t reserved420[8];   // 420..43F
+    volatile uint32_t hprt;             // 440 Host Port Control and Status
+             uint32_t reserved444[47];  // 444..4FF
 
-  //------------- Device Endpoint -------------//
-  dwc2_epin_t       epin[16];         // 900..AFF  IN Endpoints
-  dwc2_epout_t      epout[16];        // B00..CFF  OUT Endpoints
-           uint32_t reservedd00[64];  // D00..DFF
+    //------------- Host Channel -------------//
+    dwc2_channel_t    channel[16];      // 500..6FF Host Channels 0-15
+             uint32_t reserved700[64];  // 700..7FF
 
-  //------------- Power Clock -------------//
-  volatile uint32_t pcgctl;           // E00 Power and Clock Gating Control
-  volatile uint32_t pcgctl1;          // E04
-           uint32_t reservede08[126]; // E08..FFF
+    //------------- Device -----------//
+    volatile uint32_t dcfg;             // 800 Device Configuration
+    volatile uint32_t dctl;             // 804 Device Control
+    volatile uint32_t dsts;             // 808 Device Status (RO)
+             uint32_t reserved80c;      // 80C
+    volatile uint32_t diepmsk;          // 810 Device IN Endpoint Interrupt Mask
+    volatile uint32_t doepmsk;          // 814 Device OUT Endpoint Interrupt Mask
+    volatile uint32_t daint;            // 818 Device All Endpoints Interrupt
+    volatile uint32_t daintmsk;         // 81C Device All Endpoints Interrupt Mask
+    volatile uint32_t dtknqr1;          // 820 Device IN token sequence learning queue read1
+    volatile uint32_t dtknqr2;          // 824 Device IN token sequence learning queue read2
+    volatile uint32_t dvbusdis;         // 828 Device VBUS Discharge Time
+    volatile uint32_t dvbuspulse;       // 82C Device VBUS Pulsing Time
+    volatile uint32_t dthrctl;          // 830 Device threshold Control
+    volatile uint32_t diepempmsk;       // 834 Device IN Endpoint FIFO Empty Interrupt Mask
 
-  //------------- FIFOs -------------//
-  // Word-accessed only using first pointer since it auto shift
-  volatile uint32_t fifo[16][0x400];  // 1000..FFFF Endpoint FIFO
+    // Device Each Endpoint (IN/OUT) Interrupt/Mask for generating dedicated EP interrupt line
+    // require OTG_MULTI_PROC_INTRPT=1
+    volatile uint32_t deachint;         // 838 Device Each Endpoint Interrupt
+    volatile uint32_t deachmsk;         // 83C Device Each Endpoint Interrupt mask
+    volatile uint32_t diepeachmsk[16];  // 840..87C Device Each IN Endpoint mask
+    volatile uint32_t doepeachmsk[16];  // 880..8BF Device Each OUT Endpoint mask
+             uint32_t reserved8c0[16];  // 8C0..8FF
+
+    //------------- Device Endpoint -------------//
+    union {
+      dwc2_dep_t ep[2][16];            // 0: IN, 1 OUT
+      struct {
+        dwc2_epin_t  epin[16];         // 900..AFF  IN Endpoints
+        dwc2_epout_t epout[16];        // B00..CFF  OUT Endpoints
+      };
+    };
+    uint32_t reservedd00[64];  // D00..DFF
+
+    //------------- Power Clock -------------//
+    volatile uint32_t pcgctl;           // E00 Power and Clock Gating Control
+    volatile uint32_t pcgctl1;          // E04
+             uint32_t reservede08[126]; // E08..FFF
+
+    //------------- FIFOs -------------//
+    // Word-accessed only using first pointer since it auto shift
+    volatile uint32_t fifo[16][0x400];  // 1000..FFFF Endpoint FIFO
 } dwc2_regs_t;
 
 TU_VERIFY_STATIC(offsetof(dwc2_regs_t, hcfg   ) == 0x0400, "incorrect size");
@@ -957,6 +1128,8 @@ TU_VERIFY_STATIC(offsetof(dwc2_regs_t, fifo   ) == 0x1000, "incorrect size");
 #define DAINTMSK_OEPM_Msk                (0xFFFFUL << DAINTMSK_OEPM_Pos)          // 0xFFFF0000
 #define DAINTMSK_OEPM                    DAINTMSK_OEPM_Msk                        // OUT EP interrupt mask bits
 
+#define DAINT_SHIFT(_dir)            ((_dir == TUSB_DIR_IN) ? 0 : 16)
+
 #if 0
 /********************  Bit definition for OTG register  ********************/
 #define CHNUM_Pos                        (0U)
@@ -1238,6 +1411,12 @@ TU_VERIFY_STATIC(offsetof(dwc2_regs_t, fifo   ) == 0x1000, "incorrect size");
 #define GLPMCFG_ENBESL_Pos               (28U)
 #define GLPMCFG_ENBESL_Msk               (0x1UL << GLPMCFG_ENBESL_Pos)            // 0x10000000
 #define GLPMCFG_ENBESL                   GLPMCFG_ENBESL_Msk                       // Enable best effort service latency
+
+// GDFIFOCFG
+#define GDFIFOCFG_EPINFOBASE_MASK   (0xffff << 16)
+#define GDFIFOCFG_EPINFOBASE_SHIFT  16
+#define GDFIFOCFG_GDFIFOCFG_MASK    (0xffff << 0)
+#define GDFIFOCFG_GDFIFOCFG_SHIFT   0
 
 /********************  Bit definition for DIEPEACHMSK1 register  ********************/
 #define DIEPEACHMSK1_XFRCM_Pos           (0U)
@@ -1660,6 +1839,45 @@ TU_VERIFY_STATIC(offsetof(dwc2_regs_t, fifo   ) == 0x1000, "incorrect size");
 #define DIEPTXF_INEPTXFD_Msk             (0xFFFFUL << DIEPTXF_INEPTXFD_Pos)       // 0xFFFF0000
 #define DIEPTXF_INEPTXFD                 DIEPTXF_INEPTXFD_Msk                     // IN endpoint TxFIFO depth
 
+
+/********************  Bit definition for Common EPCTL register  ********************/
+#define EPCTL_MPSIZ_Pos                (0U)
+#define EPCTL_MPSIZ_Msk                (0x7FFUL << EPCTL_MPSIZ_Pos)           // 0x000007FF
+#define EPCTL_MPSIZ                    EPCTL_MPSIZ_Msk                        // Maximum packet size          //Bit 1
+#define EPCTL_USBAEP_Pos               (15U)
+#define EPCTL_USBAEP_Msk               (0x1UL << EPCTL_USBAEP_Pos)            // 0x00008000
+#define EPCTL_USBAEP                   EPCTL_USBAEP_Msk                       // USB active endpoint
+#define EPCTL_NAKSTS_Pos               (17U)
+#define EPCTL_NAKSTS_Msk               (0x1UL << EPCTL_NAKSTS_Pos)            // 0x00020000
+#define EPCTL_NAKSTS                   EPCTL_NAKSTS_Msk                       // NAK status
+#define EPCTL_EPTYP_Pos                (18U)
+#define EPCTL_EPTYP_Msk                (0x3UL << EPCTL_EPTYP_Pos)             // 0x000C0000
+#define EPCTL_EPTYP                    EPCTL_EPTYP_Msk                        // Endpoint type
+#define EPCTL_EPTYP_0                  (0x1UL << EPCTL_EPTYP_Pos)             // 0x00040000
+#define EPCTL_EPTYP_1                  (0x2UL << EPCTL_EPTYP_Pos)             // 0x00080000
+#define EPCTL_SNPM                     EPCTL_SNPM_Msk                         // Snoop mode
+#define EPCTL_STALL_Pos                (21U)
+#define EPCTL_STALL_Msk                (0x1UL << EPCTL_STALL_Pos)             // 0x00200000
+#define EPCTL_STALL                    EPCTL_STALL_Msk                        // STALL handshake
+#define EPCTL_CNAK_Pos                 (26U)
+#define EPCTL_CNAK_Msk                 (0x1UL << EPCTL_CNAK_Pos)              // 0x04000000
+#define EPCTL_CNAK                     EPCTL_CNAK_Msk                         // Clear NAK
+#define EPCTL_SNAK_Pos                 (27U)
+#define EPCTL_SNAK_Msk                 (0x1UL << EPCTL_SNAK_Pos)              // 0x08000000
+#define EPCTL_SNAK                     EPCTL_SNAK_Msk                         // Set NAK
+#define EPCTL_SD0PID_SEVNFRM_Pos       (28U)
+#define EPCTL_SD0PID_SEVNFRM_Msk       (0x1UL << EPCTL_SD0PID_SEVNFRM_Pos)    // 0x10000000
+#define EPCTL_SD0PID_SEVNFRM           EPCTL_SD0PID_SEVNFRM_Msk               // Set DATA0 PID
+#define EPCTL_SODDFRM_Pos              (29U)
+#define EPCTL_SODDFRM_Msk              (0x1UL << EPCTL_SODDFRM_Pos)           // 0x20000000
+#define EPCTL_SODDFRM                  EPCTL_SODDFRM_Msk                      // Set odd frame
+#define EPCTL_EPDIS_Pos                (30U)
+#define EPCTL_EPDIS_Msk                (0x1UL << EPCTL_EPDIS_Pos)             // 0x40000000
+#define EPCTL_EPDIS                    EPCTL_EPDIS_Msk                        // Endpoint disable
+#define EPCTL_EPENA_Pos                (31U)
+#define EPCTL_EPENA_Msk                (0x1UL << EPCTL_EPENA_Pos)             // 0x80000000
+#define EPCTL_EPENA                    EPCTL_EPENA_Msk                        // Endpoint enable
+
 /********************  Bit definition for DOEPCTL register  ********************/
 #define DOEPCTL_MPSIZ_Pos                (0U)
 #define DOEPCTL_MPSIZ_Msk                (0x7FFUL << DOEPCTL_MPSIZ_Pos)           // 0x000007FF
@@ -1710,15 +1928,19 @@ TU_VERIFY_STATIC(offsetof(dwc2_regs_t, fifo   ) == 0x1000, "incorrect size");
 #define DOEPINT_AHBERR_Pos               (2U)
 #define DOEPINT_AHBERR_Msk               (0x1UL << DOEPINT_AHBERR_Pos)            // 0x00000004
 #define DOEPINT_AHBERR                   DOEPINT_AHBERR_Msk                       // AHB Error (AHBErr) during an OUT transaction
-#define DOEPINT_STUP_Pos                 (3U)
-#define DOEPINT_STUP_Msk                 (0x1UL << DOEPINT_STUP_Pos)              // 0x00000008
-#define DOEPINT_STUP                     DOEPINT_STUP_Msk                         // SETUP phase done
+
+#define DOEPINT_SETUP_Pos                (3U)
+#define DOEPINT_SETUP_Msk                (0x1UL << DOEPINT_SETUP_Pos)             // 0x00000008
+#define DOEPINT_SETUP                    DOEPINT_SETUP_Msk                        // SETUP phase done
+
 #define DOEPINT_OTEPDIS_Pos              (4U)
 #define DOEPINT_OTEPDIS_Msk              (0x1UL << DOEPINT_OTEPDIS_Pos)           // 0x00000010
 #define DOEPINT_OTEPDIS                  DOEPINT_OTEPDIS_Msk                      // OUT token received when endpoint disabled
-#define DOEPINT_OTEPSPR_Pos              (5U)
-#define DOEPINT_OTEPSPR_Msk              (0x1UL << DOEPINT_OTEPSPR_Pos)           // 0x00000020
-#define DOEPINT_OTEPSPR                  DOEPINT_OTEPSPR_Msk                      // Status Phase Received For Control Write
+
+#define DOEPINT_STSPHSRX_Pos             (5U)
+#define DOEPINT_STSPHSRX_Msk             (0x1UL << DOEPINT_STSPHSRX_Pos)          // 0x00000020
+#define DOEPINT_STSPHSRX                  DOEPINT_STSPHSRX_Msk                    // Status Phase Received For Control Write
+
 #define DOEPINT_B2BSTUP_Pos              (6U)
 #define DOEPINT_B2BSTUP_Msk              (0x1UL << DOEPINT_B2BSTUP_Pos)           // 0x00000040
 #define DOEPINT_B2BSTUP                  DOEPINT_B2BSTUP_Msk                      // Back-to-back SETUP packets received
@@ -1731,6 +1953,7 @@ TU_VERIFY_STATIC(offsetof(dwc2_regs_t, fifo   ) == 0x1000, "incorrect size");
 #define DOEPINT_NYET_Pos                 (14U)
 #define DOEPINT_NYET_Msk                 (0x1UL << DOEPINT_NYET_Pos)              // 0x00004000
 #define DOEPINT_NYET                     DOEPINT_NYET_Msk                         // NYET interrupt
+
 #define DOEPINT_STPKTRX_Pos              (15U)
 #define DOEPINT_STPKTRX_Msk              (0x1UL << DOEPINT_STPKTRX_Pos)           // 0x00008000
 #define DOEPINT_STPKTRX                  DOEPINT_STPKTRX_Msk                      // Setup Packet Received

--- a/src/portable/wch/dcd_ch32_usbfs.c
+++ b/src/portable/wch/dcd_ch32_usbfs.c
@@ -123,7 +123,8 @@ static void update_out(uint8_t rhport, uint8_t ep, size_t rx_len) {
 }
 
 /* public functions */
-void dcd_init(uint8_t rhport) {
+bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
+  (void) rh_init;
   // init registers
   USBOTG_FS->BASE_CTRL = USBFS_CTRL_SYS_CTRL | USBFS_CTRL_INT_BUSY | USBFS_CTRL_DMA_EN;
   USBOTG_FS->UDEV_CTRL = USBFS_UDEV_CTRL_PD_DIS | USBFS_UDEV_CTRL_PORT_EN;
@@ -153,6 +154,8 @@ void dcd_init(uint8_t rhport) {
   EP_DMA(3) = (uint32_t) &data.ep3_buffer.out[0];
 
   dcd_connect(rhport);
+
+  return true;
 }
 
 void dcd_int_handler(uint8_t rhport) {

--- a/src/portable/wch/dcd_ch32_usbhs.c
+++ b/src/portable/wch/dcd_ch32_usbhs.c
@@ -131,8 +131,9 @@ static void xfer_data_packet(uint8_t ep_num, tusb_dir_t ep_dir, xfer_ctl_t* xfer
   ep_set_response_and_toggle(ep_num, ep_dir, USBHS_EP_R_RES_ACK);
 }
 
-void dcd_init(uint8_t rhport) {
+bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
   (void) rhport;
+  (void) rh_init;
 
   memset(&xfer_status, 0, sizeof(xfer_status));
 
@@ -170,6 +171,8 @@ void dcd_init(uint8_t rhport) {
 
   USBHSD->DEV_AD = 0;
   USBHSD->CONTROL |= USBHS_DEV_PU_EN;
+
+  return true;
 }
 
 void dcd_int_enable(uint8_t rhport) {

--- a/src/tusb.c
+++ b/src/tusb.c
@@ -44,21 +44,58 @@
 #include "host/usbh_pvt.h"
 #endif
 
+#define TUP_USBIP_CONTROLLER_NUM 2
+
+static tusb_role_t _rhport_role[TUP_USBIP_CONTROLLER_NUM] = { 0 };
+
 //--------------------------------------------------------------------+
 // Public API
 //--------------------------------------------------------------------+
 
-bool tusb_init(void) {
-  #if CFG_TUD_ENABLED && defined(TUD_OPT_RHPORT)
-  // init device stack CFG_TUSB_RHPORTx_MODE must be defined
-  TU_ASSERT ( tud_init(TUD_OPT_RHPORT) );
+bool tusb_rhport_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
+  //  backward compatible called with tusb_init(void)
+  #if defined(TUD_OPT_RHPORT) || defined(TUH_OPT_RHPORT)
+  if (rh_init == NULL) {
+    #if CFG_TUD_ENABLED && defined(TUD_OPT_RHPORT)
+    // init device stack CFG_TUSB_RHPORTx_MODE must be defined
+    const tusb_rhport_init_t dev_init = {
+      .role = TUSB_ROLE_DEVICE,
+      .speed = TUD_OPT_HIGH_SPEED ? TUSB_SPEED_HIGH : TUSB_SPEED_FULL
+    };
+    TU_ASSERT ( tud_rhport_init(rhport, &dev_init) );
+    _rhport_role[TUD_OPT_RHPORT] = TUSB_ROLE_DEVICE;
+    #endif
+
+    #if CFG_TUH_ENABLED && defined(TUH_OPT_RHPORT)
+    // init host stack CFG_TUSB_RHPORTx_MODE must be defined
+    const tusb_rhport_init_t host_init = {
+      .role = TUSB_ROLE_HOST,
+      .speed = TUH_OPT_HIGH_SPEED ? TUSB_SPEED_HIGH : TUSB_SPEED_FULL
+    };
+    TU_ASSERT( tuh_rhport_init(TUH_OPT_RHPORT, &host_init) );
+    _rhport_role[TUH_OPT_RHPORT] = TUSB_ROLE_HOST;
+    #endif
+
+    return true;
+  }
   #endif
 
-  #if CFG_TUH_ENABLED && defined(TUH_OPT_RHPORT)
-  // init host stack CFG_TUSB_RHPORTx_MODE must be defined
-  TU_ASSERT( tuh_init(TUH_OPT_RHPORT) );
+  // new API with explicit rhport and role
+  TU_ASSERT(rhport < TUP_USBIP_CONTROLLER_NUM && rh_init->role != TUSB_ROLE_INVALID);
+
+  #if CFG_TUD_ENABLED
+  if (rh_init->role == TUSB_ROLE_DEVICE) {
+    TU_ASSERT(tud_rhport_init(rhport, rh_init));
+  }
   #endif
 
+  #if CFG_TUH_ENABLED
+  if (rh_init->role == TUSB_ROLE_HOST) {
+    TU_ASSERT(tuh_rhport_init(rhport, rh_init));
+  }
+  #endif
+
+  _rhport_role[rhport] = rh_init->role;
   return true;
 }
 
@@ -74,6 +111,23 @@ bool tusb_inited(void) {
   #endif
 
   return ret;
+}
+
+void tusb_int_handler(uint8_t rhport, bool in_isr) {
+  TU_VERIFY(rhport < TUP_USBIP_CONTROLLER_NUM,);
+
+  #if CFG_TUD_ENABLED
+  if (_rhport_role[rhport] == TUSB_ROLE_DEVICE) {
+    (void) in_isr;
+    dcd_int_handler(rhport);
+  }
+  #endif
+
+  #if CFG_TUH_ENABLED
+  if (_rhport_role[rhport] == TUSB_ROLE_HOST) {
+    hcd_int_handler(rhport, in_isr);
+  }
+  #endif
 }
 
 //--------------------------------------------------------------------+
@@ -221,13 +275,17 @@ uint16_t tu_desc_get_interface_total_len(tusb_desc_interface_t const* desc_itf, 
 
 bool tu_edpt_stream_init(tu_edpt_stream_t* s, bool is_host, bool is_tx, bool overwritable,
                          void* ff_buf, uint16_t ff_bufsize, uint8_t* ep_buf, uint16_t ep_bufsize) {
-  osal_mutex_t new_mutex = osal_mutex_create(&s->ff_mutexdef);
-  (void) new_mutex;
   (void) is_tx;
 
   s->is_host = is_host;
   tu_fifo_config(&s->ff, ff_buf, ff_bufsize, 1, overwritable);
-  tu_fifo_config_mutex(&s->ff, is_tx ? new_mutex : NULL, is_tx ? NULL : new_mutex);
+
+  #if OSAL_MUTEX_REQUIRED
+  if (ff_buf && ff_bufsize) {
+    osal_mutex_t new_mutex = osal_mutex_create(&s->ff_mutexdef);
+    tu_fifo_config_mutex(&s->ff, is_tx ? new_mutex : NULL, is_tx ? NULL : new_mutex);
+  }
+  #endif
 
   s->ep_buf = ep_buf;
   s->ep_bufsize = ep_bufsize;
@@ -244,43 +302,40 @@ bool tu_edpt_stream_deinit(tu_edpt_stream_t* s) {
   return true;
 }
 
-TU_ATTR_ALWAYS_INLINE static inline
-bool stream_claim(tu_edpt_stream_t* s) {
+TU_ATTR_ALWAYS_INLINE static inline bool stream_claim(uint8_t hwid, tu_edpt_stream_t* s) {
   if (s->is_host) {
     #if CFG_TUH_ENABLED
-    return usbh_edpt_claim(s->daddr, s->ep_addr);
+    return usbh_edpt_claim(hwid, s->ep_addr);
     #endif
   } else {
     #if CFG_TUD_ENABLED
-    return usbd_edpt_claim(s->rhport, s->ep_addr);
+    return usbd_edpt_claim(hwid, s->ep_addr);
     #endif
   }
   return false;
 }
 
-TU_ATTR_ALWAYS_INLINE static inline
-bool stream_xfer(tu_edpt_stream_t* s, uint16_t count) {
+TU_ATTR_ALWAYS_INLINE static inline bool stream_xfer(uint8_t hwid, tu_edpt_stream_t* s, uint16_t count) {
   if (s->is_host) {
     #if CFG_TUH_ENABLED
-    return usbh_edpt_xfer(s->daddr, s->ep_addr, count ? s->ep_buf : NULL, count);
+    return usbh_edpt_xfer(hwid, s->ep_addr, count ? s->ep_buf : NULL, count);
     #endif
   } else {
     #if CFG_TUD_ENABLED
-    return usbd_edpt_xfer(s->rhport, s->ep_addr, count ? s->ep_buf : NULL, count);
+    return usbd_edpt_xfer(hwid, s->ep_addr, count ? s->ep_buf : NULL, count);
     #endif
   }
   return false;
 }
 
-TU_ATTR_ALWAYS_INLINE static inline
-bool stream_release(tu_edpt_stream_t* s) {
+TU_ATTR_ALWAYS_INLINE static inline bool stream_release(uint8_t hwid, tu_edpt_stream_t* s) {
   if (s->is_host) {
     #if CFG_TUH_ENABLED
-    return usbh_edpt_release(s->daddr, s->ep_addr);
+    return usbh_edpt_release(hwid, s->ep_addr);
     #endif
   } else {
     #if CFG_TUD_ENABLED
-    return usbd_edpt_release(s->rhport, s->ep_addr);
+    return usbd_edpt_release(hwid, s->ep_addr);
     #endif
   }
   return false;
@@ -289,83 +344,117 @@ bool stream_release(tu_edpt_stream_t* s) {
 //--------------------------------------------------------------------+
 // Stream Write
 //--------------------------------------------------------------------+
-bool tu_edpt_stream_write_zlp_if_needed(tu_edpt_stream_t* s, uint32_t last_xferred_bytes) {
+bool tu_edpt_stream_write_zlp_if_needed(uint8_t hwid, tu_edpt_stream_t* s, uint32_t last_xferred_bytes) {
   // ZLP condition: no pending data, last transferred bytes is multiple of packet size
-  TU_VERIFY(!tu_fifo_count(&s->ff) && last_xferred_bytes && (0 == (last_xferred_bytes & (s->ep_packetsize - 1))));
-  TU_VERIFY(stream_claim(s));
-  TU_ASSERT(stream_xfer(s, 0));
+  const uint16_t mps = s->is_mps512 ? TUSB_EPSIZE_BULK_HS : TUSB_EPSIZE_BULK_FS;
+  TU_VERIFY(!tu_fifo_count(&s->ff) && last_xferred_bytes && (0 == (last_xferred_bytes & (mps - 1))));
+  TU_VERIFY(stream_claim(hwid, s));
+  TU_ASSERT(stream_xfer(hwid, s, 0));
   return true;
 }
 
-uint32_t tu_edpt_stream_write_xfer(tu_edpt_stream_t* s) {
+uint32_t tu_edpt_stream_write_xfer(uint8_t hwid, tu_edpt_stream_t* s) {
   // skip if no data
   TU_VERIFY(tu_fifo_count(&s->ff), 0);
 
-  // Claim the endpoint
-  TU_VERIFY(stream_claim(s), 0);
+  TU_VERIFY(stream_claim(hwid, s), 0);
 
   // Pull data from FIFO -> EP buf
   uint16_t const count = tu_fifo_read_n(&s->ff, s->ep_buf, s->ep_bufsize);
 
   if (count) {
-    TU_ASSERT(stream_xfer(s, count), 0);
+    TU_ASSERT(stream_xfer(hwid, s, count), 0);
     return count;
   } else {
     // Release endpoint since we don't make any transfer
     // Note: data is dropped if terminal is not connected
-    stream_release(s);
+    stream_release(hwid, s);
     return 0;
   }
 }
 
-uint32_t tu_edpt_stream_write(tu_edpt_stream_t* s, void const* buffer, uint32_t bufsize) {
+uint32_t tu_edpt_stream_write(uint8_t hwid, tu_edpt_stream_t* s, void const* buffer, uint32_t bufsize) {
   TU_VERIFY(bufsize); // TODO support ZLP
-  uint16_t ret = tu_fifo_write_n(&s->ff, buffer, (uint16_t) bufsize);
 
-  // flush if fifo has more than packet size or
-  // in rare case: fifo depth is configured too small (which never reach packet size)
-  if ((tu_fifo_count(&s->ff) >= s->ep_packetsize) || (tu_fifo_depth(&s->ff) < s->ep_packetsize)) {
-    tu_edpt_stream_write_xfer(s);
+  if (0 == tu_fifo_depth(&s->ff)) {
+    // no fifo for buffered
+    TU_VERIFY(stream_claim(hwid, s), 0);
+    const uint32_t xact_len = tu_min32(bufsize, s->ep_bufsize);
+    memcpy(s->ep_buf, buffer, xact_len);
+    TU_ASSERT(stream_xfer(hwid, s, (uint16_t) xact_len), 0);
+    return xact_len;
+  } else {
+    const uint16_t ret = tu_fifo_write_n(&s->ff, buffer, (uint16_t) bufsize);
+
+    // flush if fifo has more than packet size or
+    // in rare case: fifo depth is configured too small (which never reach packet size)
+    const uint16_t mps = s->is_mps512 ? TUSB_EPSIZE_BULK_HS : TUSB_EPSIZE_BULK_FS;
+    if ((tu_fifo_count(&s->ff) >= mps) || (tu_fifo_depth(&s->ff) < mps)) {
+      tu_edpt_stream_write_xfer(hwid, s);
+    }
+    return ret;
   }
+}
 
-  return ret;
+uint32_t tu_edpt_stream_write_available(uint8_t hwid, tu_edpt_stream_t* s) {
+  if (tu_fifo_depth(&s->ff)) {
+    return (uint32_t) tu_fifo_remaining(&s->ff);
+  } else {
+    bool is_busy = true;
+    if (s->is_host) {
+      #if CFG_TUH_ENABLED
+      is_busy = usbh_edpt_busy(hwid, s->ep_addr);
+      #endif
+    } else {
+      #if CFG_TUD_ENABLED
+      is_busy = usbd_edpt_busy(hwid, s->ep_addr);
+      #endif
+    }
+    return is_busy ? 0 : s->ep_bufsize;
+  }
 }
 
 //--------------------------------------------------------------------+
 // Stream Read
 //--------------------------------------------------------------------+
-uint32_t tu_edpt_stream_read_xfer(tu_edpt_stream_t* s) {
-  uint16_t available = tu_fifo_remaining(&s->ff);
-
-  // Prepare for incoming data but only allow what we can store in the ring buffer.
-  // TODO Actually we can still carry out the transfer, keeping count of received bytes
-  // and slowly move it to the FIFO when read().
-  // This pre-check reduces endpoint claiming
-  TU_VERIFY(available >= s->ep_packetsize);
-
-  // claim endpoint
-  TU_VERIFY(stream_claim(s), 0);
-
-  // get available again since fifo can be changed before endpoint is claimed
-  available = tu_fifo_remaining(&s->ff);
-
-  if (available >= s->ep_packetsize) {
-    // multiple of packet size limit by ep bufsize
-    uint16_t count = (uint16_t) (available & ~(s->ep_packetsize - 1));
-    count = tu_min16(count, s->ep_bufsize);
-
-    TU_ASSERT(stream_xfer(s, count), 0);
-    return count;
+uint32_t tu_edpt_stream_read_xfer(uint8_t hwid, tu_edpt_stream_t* s) {
+  if (0 == tu_fifo_depth(&s->ff)) {
+    // no fifo for buffered
+    TU_VERIFY(stream_claim(hwid, s), 0);
+    TU_ASSERT(stream_xfer(hwid, s, s->ep_bufsize), 0);
+    return s->ep_bufsize;
   } else {
-    // Release endpoint since we don't make any transfer
-    stream_release(s);
-    return 0;
+    const uint16_t mps = s->is_mps512 ? TUSB_EPSIZE_BULK_HS : TUSB_EPSIZE_BULK_FS;
+    uint16_t available = tu_fifo_remaining(&s->ff);
+
+    // Prepare for incoming data but only allow what we can store in the ring buffer.
+    // TODO Actually we can still carry out the transfer, keeping count of received bytes
+    // and slowly move it to the FIFO when read().
+    // This pre-check reduces endpoint claiming
+    TU_VERIFY(available >= mps);
+
+    TU_VERIFY(stream_claim(hwid, s), 0);
+
+    // get available again since fifo can be changed before endpoint is claimed
+    available = tu_fifo_remaining(&s->ff);
+
+    if (available >= mps) {
+      // multiple of packet size limit by ep bufsize
+      uint16_t count = (uint16_t) (available & ~(mps - 1));
+      count = tu_min16(count, s->ep_bufsize);
+      TU_ASSERT(stream_xfer(hwid, s, count), 0);
+      return count;
+    } else {
+      // Release endpoint since we don't make any transfer
+      stream_release(hwid, s);
+      return 0;
+    }
   }
 }
 
-uint32_t tu_edpt_stream_read(tu_edpt_stream_t* s, void* buffer, uint32_t bufsize) {
+uint32_t tu_edpt_stream_read(uint8_t hwid, tu_edpt_stream_t* s, void* buffer, uint32_t bufsize) {
   uint32_t num_read = tu_fifo_read_n(&s->ff, buffer, (uint16_t) bufsize);
-  tu_edpt_stream_read_xfer(s);
+  tu_edpt_stream_read_xfer(hwid, s);
   return num_read;
 }
 

--- a/src/tusb.h
+++ b/src/tusb.h
@@ -130,16 +130,43 @@
 // APPLICATION API
 //--------------------------------------------------------------------+
 
-// Initialize device/host stack
+
+#if CFG_TUH_ENABLED || CFG_TUD_ENABLED
+
+// Internal helper for backward compatible with tusb_init(void)
+bool tusb_rhport_init(uint8_t rhport, const tusb_rhport_init_t* rh_init);
+
+// Initialize roothub port with device/host role
 // Note: when using with RTOS, this should be called after scheduler/kernel is started.
-// Otherwise it could cause kernel issue since USB IRQ handler does use RTOS queue API.
-bool tusb_init(void);
+// Otherwise, it could cause kernel issue since USB IRQ handler does use RTOS queue API.
+// Note2: defined as macro for backward compatible with tusb_init(void), can be changed to function in the future.
+#if defined(TUD_OPT_RHPORT) || defined(TUH_OPT_RHPORT)
+  #define _tusb_init_arg0()        tusb_rhport_init(0, NULL)
+#else
+  #define _tusb_init_arg0()        TU_VERIFY_STATIC(false, "CFG_TUSB_RHPORT0_MODE/CFG_TUSB_RHPORT1_MODE must be defined")
+#endif
+
+#define _tusb_init_arg1(_rhport)             _tusb_init_arg0()
+#define _tusb_init_arg2(_rhport, _rh_init)   tusb_rhport_init(_rhport, _rh_init)
+#define tusb_init(...)                       TU_FUNC_OPTIONAL_ARG(_tusb_init, __VA_ARGS__)
 
 // Check if stack is initialized
 bool tusb_inited(void);
 
+// Called to handle usb interrupt/event. tusb_init(rhport, role) must be called before
+void tusb_int_handler(uint8_t rhport, bool in_isr);
+
 // TODO
 // bool tusb_teardown(void);
+
+#else
+
+#define tusb_init(...)  (false)
+#define tusb_int_handler(...)  do {}while(0)
+#define tusb_inited()  (false)
+
+#endif
+
 
 #ifdef __cplusplus
  }

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -91,6 +91,7 @@
 #define OPT_MCU_STM32U5           313 ///< ST U5
 #define OPT_MCU_STM32L5           314 ///< ST L5
 #define OPT_MCU_STM32H5           315 ///< ST H5
+#define OPT_MCU_STM32U0           316 ///< ST U0
 
 // Sony
 #define OPT_MCU_CXD56             400 ///< SONY CXD56
@@ -123,6 +124,7 @@
 #define OPT_MCU_ESP32C6           904 ///< Espressif ESP32-C6
 #define OPT_MCU_ESP32C2           905 ///< Espressif ESP32-C2
 #define OPT_MCU_ESP32H2           906 ///< Espressif ESP32-H2
+#define OPT_MCU_ESP32P4           907 ///< Espressif ESP32-P4
 #define TUP_MCU_ESPRESSIF         (CFG_TUSB_MCU >= 900 && CFG_TUSB_MCU < 1000) // check if Espressif MCU
 
 // Dialog
@@ -228,7 +230,7 @@
 #define OPT_MODE_SPEED_MASK     0xff00
 
 //--------------------------------------------------------------------+
-// Include tusb_config.h and tusb_mcu.h
+// Include tusb_config.h
 //--------------------------------------------------------------------+
 
 // Allow to use command line to change the config name/location
@@ -236,6 +238,33 @@
   #include CFG_TUSB_CONFIG_FILE
 #else
   #include "tusb_config.h"
+#endif
+
+//--------------------------------------------------------------------+
+// USBIP
+//--------------------------------------------------------------------+
+
+// DWC2 controller: use DMA for data transfer
+// For processors with data cache enabled, USB endpoint buffer region
+// (defined by CFG_TUSB_MEM_SECTION) must be declared as non-cacheable.
+// For example, on Cortex-M7 the MPU region can be configured as normal
+// non-cacheable, with RASR register value: TEX=1 C=0 B=0 S=0.
+#ifndef CFG_TUD_DWC2_DMA
+  #define CFG_TUD_DWC2_DMA 0
+#endif
+
+// Enable PIO-USB software host controller
+#ifndef CFG_TUH_RPI_PIO_USB
+  #define CFG_TUH_RPI_PIO_USB 0
+#endif
+
+#ifndef CFG_TUD_RPI_PIO_USB
+  #define CFG_TUD_RPI_PIO_USB 0
+#endif
+
+// MAX3421 Host controller option
+#ifndef CFG_TUH_MAX3421
+  #define CFG_TUH_MAX3421  0
 #endif
 
 #include "common/tusb_mcu.h"
@@ -546,20 +575,6 @@
 
 #ifndef CFG_TUH_API_EDPT_XFER
   #define CFG_TUH_API_EDPT_XFER 0
-#endif
-
-// Enable PIO-USB software host controller
-#ifndef CFG_TUH_RPI_PIO_USB
-  #define CFG_TUH_RPI_PIO_USB 0
-#endif
-
-#ifndef CFG_TUD_RPI_PIO_USB
-  #define CFG_TUD_RPI_PIO_USB 0
-#endif
-
-// MAX3421 Host controller option
-#ifndef CFG_TUH_MAX3421
-  #define CFG_TUH_MAX3421  0
 #endif
 
 //--------------------------------------------------------------------+


### PR DESCRIPTION
update tinyusb to commit 8b1e40c3e2447de5b4a86bbcdcc0344946a4793d which use new style of tusb_init()/tuh_init()/tud_init(). This should fix #465 building with latest esp32 core v3.0.7