### PR TITLE
Call out Arduino namespace in Adafruit_USBH_CDC

### DIFF
--- a/src/arduino/cdc/Adafruit_USBH_CDC.h
+++ b/src/arduino/cdc/Adafruit_USBH_CDC.h
@@ -27,7 +27,7 @@
 
 #include "HardwareSerial.h"
 
-class Adafruit_USBH_CDC : public HardwareSerial {
+class Adafruit_USBH_CDC : public arduino::HardwareSerial {
 public:
   Adafruit_USBH_CDC(void);
 


### PR DESCRIPTION
The `HardwareSerial` Arduino base class does not always get exposed with a `using namespace arduino` statement, and with the latest Arduino API 1.5.1 this causes Arduino-Pico to fail building the CDC serial port examples.

https://github.com/earlephilhower/arduino-pico/pull/2797

This change is compatible with all other Arduino API levels for the last 6 years since the encapsulation was done then:
https://github.com/arduino/ArduinoCore-API/commit/fc0c12d7faf43782fd44d2e1384abfef6109da21
