### PR TITLE
USB Device Descriptor Max Power is not configurable #504

### DIFF
--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -186,7 +186,7 @@ void Adafruit_USBD_Device::clearConfiguration(void) {
   uint8_t const dev_cfg[sizeof(tusb_desc_configuration_t)] = {
       TUD_CONFIG_DESCRIPTOR(1, 0, 0, sizeof(tusb_desc_configuration_t),
                             TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP | TU_BIT(7),
-                            100),
+                            USB_CONFIG_POWER),
   };
 
   memcpy(_desc_cfg_buffer, dev_cfg, sizeof(tusb_desc_configuration_t));


### PR DESCRIPTION
Looking at Adafruit_USBD_Device.cpp, there's a define macro for the Max Power but it's never used.

at line 85:
```
#ifndef USB_CONFIG_POWER
#define USB_CONFIG_POWER 100
#endif
```
At line 186, the power is hardcoded to 100:
```
  uint8_t const dev_cfg[sizeof(tusb_desc_configuration_t)] = {
      TUD_CONFIG_DESCRIPTOR(1, 0, 0, sizeof(tusb_desc_configuration_t),
                            TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP | TU_BIT(7),
                            100),
  };
```

I simply replaced the 100 with USB_CONFIG_POWER.