### PR TITLE
add setConfigurationMaxPower() and setConfigurationAttribute

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,7 +46,7 @@ body:
   - type: input
     attributes:
       label: TinyUSB Library version
-      placeholder: "Release version or github latest"
+      placeholder: "Release version or commit SHA"
     validations:
       required: true
 

--- a/src/arduino/Adafruit_USBD_Device.h
+++ b/src/arduino/Adafruit_USBD_Device.h
@@ -80,6 +80,21 @@ public:
   // Clear/Reset configuration descriptor
   void clearConfiguration(void);
 
+  // Set configuration attribute
+  void setConfigurationAttribute(uint8_t attribute) {
+    _desc_cfg[offsetof(tusb_desc_configuration_t, bmAttributes)] = attribute;
+  }
+
+  // Set max power consumption in mA (absolute max is 510ma)
+  bool setConfigurationMaxPower(uint16_t power_ma) {
+    if (power_ma > 255 * 2u) {
+      return false;
+    }
+    _desc_cfg[offsetof(tusb_desc_configuration_t, bMaxPower)] =
+        (uint8_t)(power_ma / 2);
+    return true;
+  }
+
   // Provide user buffer for configuration descriptor, if total length > 256
   void setConfigurationBuffer(uint8_t *buf, uint32_t buflen);
 


### PR DESCRIPTION
follow up to #505 , fix #421
This pull request introduces two new methods to the `Adafruit_USBD_Device` class in `src/arduino/Adafruit_USBD_Device.h` to enhance configuration management for USB devices. These changes allow setting configuration attributes and specifying maximum power consumption.

### Enhancements to USB configuration management:

* **Added `setConfigurationAttribute` method**: This method allows setting the configuration attribute by modifying the `bmAttributes` field in the configuration descriptor.
* **Added `setConfigurationMaxPower` method**: This method enables setting the maximum power consumption (in mA) for the USB device, with a validation check to ensure the value does not exceed the USB specification's limit of 510mA.