### PR TITLE
update msc sdcad example to work with metro rp2040

### DIFF
--- a/examples/MassStorage/msc_sdfat/msc_sdfat.ino
+++ b/examples/MassStorage/msc_sdfat/msc_sdfat.ino
@@ -10,14 +10,30 @@
 *********************************************************************/
 
 /* This example expose SD card as mass storage using
- * SdFat Library
+ * - SdFat https://github.com/adafruit/SdFat
  */
 
 #include "SPI.h"
 #include "SdFat_Adafruit_Fork.h"
 #include "Adafruit_TinyUSB.h"
 
-const int chipSelect = 10;
+//--------------------------------------------------------------------+
+// SDCard Config
+//--------------------------------------------------------------------+
+
+#if defined(ARDUINO_PYPORTAL_M4) || defined(ARDUINO_PYPORTAL_M4_TITANO)
+  // PyPortal has on-board card reader
+  #define SDCARD_CS            32
+  #define SDCARD_DETECT        33
+  #define SDCARD_DETECT_ACTIVE HIGH
+#elif defined(ARDUINO_ADAFRUIT_METRO_RP2040)
+  #define SDCARD_CS            23
+  #define SDCARD_DETECT        15
+  #define SDCARD_DETECT_ACTIVE LOW
+#else
+  #define SDCARD_CS       10
+  // no detect
+#endif
 
 // File system on SD Card
 SdFat sd;
@@ -57,16 +73,16 @@ void setup() {
     TinyUSBDevice.attach();
   }
 
-  //while ( !Serial ) delay(10);   // wait for native usb
+  while ( !Serial ) delay(10);   // wait for native usb
   Serial.println("Adafruit TinyUSB Mass Storage SD Card example");
   Serial.print("\nInitializing SD card ... ");
-  Serial.print("CS = "); Serial.println(chipSelect);
+  Serial.print("CS = "); Serial.println(SDCARD_CS);
 
-  if ( !sd.begin(chipSelect, SD_SCK_MHZ(50)) ) {
+  if ( !sd.begin(SDCARD_CS, SD_SCK_MHZ(50)) ) {
     Serial.println("initialization failed. Things to check:");
     Serial.println("* is a card inserted?");
     Serial.println("* is your wiring correct?");
-    Serial.println("* did you change the chipSelect pin to match your shield or module?");
+    Serial.println("* did you change the SDCARD_CS pin to match your shield or module?");
     while (1) delay(1);
   }
 


### PR DESCRIPTION
This pull request introduces improvements to SD card handling and code style consistency in two example files: `msc_external_flash_sdcard.ino` and `msc_sdfat.ino`. The changes include adding SD card configuration for the `ARDUINO_ADAFRUIT_METRO_RP2040` board, enhancing SD card initialization logic, and cleaning up code formatting for better readability.

### SD Card Configuration Updates:
* Added specific `SDCARD_CS`, `SDCARD_DETECT`, and `SDCARD_DETECT_ACTIVE` definitions for the `ARDUINO_ADAFRUIT_METRO_RP2040` board in `msc_external_flash_sdcard.ino` and `msc_sdfat.ino`, ensuring compatibility with this board. [[1]](diffhunk://#diff-14ab6efd157f9212ace26549d297d7faa5a302e8ce60951645c27176bcd41be0R50-R54) [[2]](diffhunk://#diff-cb22a8910f3ba795d02518ee6d091215256a0fe85f4a6a5eb55478f72572ccc9L13-R36)

### SD Card Initialization and Logic Improvements:
* Updated `init_sdcard()` and `sdcard_ready_callback()` to use the new `SDCARD_DETECT_ACTIVE` macro, improving flexibility for boards with different active states for SD card detection. [[1]](diffhunk://#diff-14ab6efd157f9212ace26549d297d7faa5a302e8ce60951645c27176bcd41be0L121-R129) [[2]](diffhunk://#diff-14ab6efd157f9212ace26549d297d7faa5a302e8ce60951645c27176bcd41be0L278-R279)
* Replaced the hardcoded `chipSelect` variable with `SDCARD_CS` in `msc_sdfat.ino` for consistency with the updated configuration.

### Code Formatting and Readability Enhancements:
* Reformatted function definitions (`init_sdcard`, `print_rootdir`, and `loop`) to use a consistent inline style for braces, aligning with modern C++ coding standards. [[1]](diffhunk://#diff-14ab6efd157f9212ace26549d297d7faa5a302e8ce60951645c27176bcd41be0L121-R129) [[2]](diffhunk://#diff-14ab6efd157f9212ace26549d297d7faa5a302e8ce60951645c27176bcd41be0L154-R166) [[3]](diffhunk://#diff-14ab6efd157f9212ace26549d297d7faa5a302e8ce60951645c27176bcd41be0L176-R182)
* Removed unnecessary blank lines in `msc_external_flash_sdcard.ino` to improve code readability.