### PR TITLE
resolve msc sdcard example conflict with host espcially macos

### DIFF
--- a/examples/MassStorage/msc_sdfat/msc_sdfat.ino
+++ b/examples/MassStorage/msc_sdfat/msc_sdfat.ino
@@ -20,40 +20,52 @@
 //--------------------------------------------------------------------+
 // SDCard Config
 //--------------------------------------------------------------------+
-
 #if defined(ARDUINO_PYPORTAL_M4) || defined(ARDUINO_PYPORTAL_M4_TITANO)
   // PyPortal has on-board card reader
   #define SDCARD_CS            32
   #define SDCARD_DETECT        33
   #define SDCARD_DETECT_ACTIVE HIGH
+
 #elif defined(ARDUINO_ADAFRUIT_METRO_RP2040)
-  #define SDCARD_CS            23
+  #define SDIO_CLK_PIN  18
+  #define SDIO_CMD_PIN  19 // MOSI
+  #define SDIO_DAT0_PIN 20 // DAT1: 21, DAT2: 22, DAT3: 23
+
   #define SDCARD_DETECT        15
   #define SDCARD_DETECT_ACTIVE LOW
+
+#elif defined(ARDUINO_ADAFRUIT_METRO_RP2350)
+  // Note: not working yet (need troubleshoot later)
+  #define SDIO_CLK_PIN  34
+  #define SDIO_CMD_PIN  35 // MOSI
+  #define SDIO_DAT0_PIN 36 // DAT1: 37, DAT2: 38, DAT3: 39
+
+  #define SDCARD_DETECT        40
+  #define SDCARD_DETECT_ACTIVE LOW
+
 #else
+  // Use SPI, no detect
   #define SDCARD_CS       10
-  // no detect
+#endif
+
+#if defined(SDIO_CLK_PIN) && defined(SDIO_CMD_PIN) && defined(SDIO_DAT0_PIN)
+  #define SD_CONFIG SdioConfig(SDIO_CLK_PIN, SDIO_CMD_PIN, SDIO_DAT0_PIN)
+#else
+  #define SD_CONFIG SdSpiConfig(SDCARD_CS, SHARED_SPI, SD_SCK_MHZ(50))
 #endif
 
 // File system on SD Card
 SdFat sd;
 
-SdFile root;
-SdFile file;
-
 // USB Mass Storage object
 Adafruit_USBD_MSC usb_msc;
 
-// Set to true when PC write to flash
-bool fs_changed;
-
 // the setup function runs once when you press reset or power the board
 void setup() {
-  Serial.begin(115200);
-
 #ifdef LED_BUILTIN
   pinMode(LED_BUILTIN, OUTPUT);
 #endif
+  Serial.begin(115200);
 
   // Set disk vendor id, product id and revision with string up to 8, 16, 4 characters respectively
   usb_msc.setID("Adafruit", "SD Card", "1.0");
@@ -73,26 +85,20 @@ void setup() {
     TinyUSBDevice.attach();
   }
 
-  while ( !Serial ) delay(10);   // wait for native usb
+  //while ( !Serial ) delay(10);   // wait for native usb
   Serial.println("Adafruit TinyUSB Mass Storage SD Card example");
   Serial.print("\nInitializing SD card ... ");
-  Serial.print("CS = "); Serial.println(SDCARD_CS);
 
-  if ( !sd.begin(SDCARD_CS, SD_SCK_MHZ(50)) ) {
+  if (!sd.begin(SD_CONFIG)) {
     Serial.println("initialization failed. Things to check:");
-    Serial.println("* is a card inserted?");
-    Serial.println("* is your wiring correct?");
-    Serial.println("* did you change the SDCARD_CS pin to match your shield or module?");
+    Serial.println("- is a card inserted?");
+    Serial.println("- is your wiring correct?");
+    Serial.println("- did you change the SDCARD_CS or SDIO pin to match your shield or module?");
     while (1) delay(1);
   }
 
   // Size in blocks (512 bytes)
-#if SD_FAT_VERSION >= 20000
   uint32_t block_count = sd.card()->sectorCount();
-#else
-  uint32_t block_count = sd.card()->cardSize();
-#endif
-
   Serial.print("Volume size (MB):  ");
   Serial.println((block_count/2) / 1024);
 
@@ -101,51 +107,17 @@ void setup() {
 
   // MSC is ready for read/write
   usb_msc.setUnitReady(true);
-
-  fs_changed = true; // to print contents initially
 }
 
 void loop() {
-  if ( fs_changed ) {
-    root.open("/");
-    Serial.println("SD contents:");
-
-    // Open next file in root.
-    // Warning, openNext starts at the current directory position
-    // so a rewind of the directory may be required.
-    while ( file.openNext(&root, O_RDONLY) ) {
-      file.printFileSize(&Serial);
-      Serial.write(' ');
-      file.printName(&Serial);
-      if ( file.isDir() ) {
-        // Indicate a directory.
-        Serial.write('/');
-      }
-      Serial.println();
-      file.close();
-    }
-
-    root.close();
-
-    Serial.println();
-
-    fs_changed = false;
-    delay(1000); // refresh every 0.5 second
-  }
+  // noting to do
 }
 
 // Callback invoked when received READ10 command.
 // Copy disk's data to buffer (up to bufsize) and
 // return number of copied bytes (must be multiple of block size)
 int32_t msc_read_cb (uint32_t lba, void* buffer, uint32_t bufsize) {
-  bool rc;
-
-#if SD_FAT_VERSION >= 20000
-  rc = sd.card()->readSectors(lba, (uint8_t*) buffer, bufsize/512);
-#else
-  rc = sd.card()->readBlocks(lba, (uint8_t*) buffer, bufsize/512);
-#endif
-
+  bool rc = sd.card()->readSectors(lba, (uint8_t*) buffer, bufsize/512);
   return rc ? bufsize : -1;
 }
 
@@ -153,34 +125,18 @@ int32_t msc_read_cb (uint32_t lba, void* buffer, uint32_t bufsize) {
 // Process data in buffer to disk's storage and 
 // return number of written bytes (must be multiple of block size)
 int32_t msc_write_cb (uint32_t lba, uint8_t* buffer, uint32_t bufsize) {
-  bool rc;
-
 #ifdef LED_BUILTIN
   digitalWrite(LED_BUILTIN, HIGH);
 #endif
-
-#if SD_FAT_VERSION >= 20000
-  rc = sd.card()->writeSectors(lba, buffer, bufsize/512);
-#else
-  rc = sd.card()->writeBlocks(lba, buffer, bufsize/512);
-#endif
-
+  bool rc = sd.card()->writeSectors(lba, buffer, bufsize/512);
   return rc ? bufsize : -1;
 }
 
 // Callback invoked when WRITE10 command is completed (status received and accepted by host).
 // used to flush any pending cache.
 void msc_flush_cb (void) {
-#if SD_FAT_VERSION >= 20000
   sd.card()->syncDevice();
-#else
-  sd.card()->syncBlocks();
-#endif
-
-  // clear file system's cache to force refresh
-  sd.cacheClear();
-
-  fs_changed = true;
+  sd.cacheClear();   // clear file system's cache to force refresh
 
 #ifdef LED_BUILTIN
   digitalWrite(LED_BUILTIN, LOW);


### PR DESCRIPTION
- use SDIO (pio) for rp2040/rp2350
- remove printing flash/sdcard contents to Serial since it conflict with host, which can cause conflict in spi/sdio transport and/or correupt cache,sector
- This "fix" completely remove the sdcard contents dump. a better fix would be marking the SDcard as not ready (return false in TEST_UNIT_READY) while performming self-reading, but that would maybe take a bit of time. I will do it later if needed. 
- supercede and close #532 fix #455

@mikeysklar let me know if this works for you (you need to update Sdfat to v2.3.50)

PS: The conflict happen with macos more often since macos does lots of hidden writing of meta data file e.g `.DS_Store`