### PR TITLE
Remove redundant USE_TINYUSB macro from PlatformIO library manifest

### DIFF
--- a/library.json
+++ b/library.json
@@ -10,8 +10,7 @@
     "frameworks": "*",
     "platforms": "*",
     "build": {
-        "libArchive": false,
-        "flags": "-DUSE_TINYUSB"
+        "libArchive": false
     },
     "authors":
     [


### PR DESCRIPTION
The `USE_TINYUSB` macro (added in #336) is already handled by the PlatformIO build script for Adafruit nRF52 core and shouldn’t be statically declared in the library manifest file.