### PR TITLE
Fixes #296

### DIFF
--- a/src/arduino/Adafruit_USBH_Host.cpp
+++ b/src/arduino/Adafruit_USBH_Host.cpp
@@ -154,7 +154,6 @@ TU_ATTR_WEAK void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance,
   (void)len;
 }
 
-
 //--------------------------------------------------------------------+
 // USB Host using MAX3421E
 //--------------------------------------------------------------------+

--- a/src/arduino/Adafruit_USBH_Host.cpp
+++ b/src/arduino/Adafruit_USBH_Host.cpp
@@ -144,36 +144,6 @@ void Adafruit_USBH_Host::task(uint32_t timeout_ms, bool in_isr) {
   tuh_task_ext(timeout_ms, in_isr);
 }
 
-// Invoked when device with hid interface is mounted
-// Report descriptor is also available for use.
-// tuh_hid_parse_report_descriptor() can be used to parse common/simple enough
-// descriptor. Note: if report descriptor length > CFG_TUH_ENUMERATION_BUFSIZE,
-// it will be skipped therefore report_desc = NULL, desc_len = 0
-TU_ATTR_WEAK void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance,
-                                   uint8_t const *desc_report,
-                                   uint16_t desc_len) {
-  (void)dev_addr;
-  (void)instance;
-  (void)desc_report;
-  (void)desc_len;
-}
-
-// Invoked when device with hid interface is un-mounted
-TU_ATTR_WEAK void tuh_hid_umount_cb(uint8_t dev_addr, uint8_t instance) {
-  (void)dev_addr;
-  (void)instance;
-}
-
-// Invoked when received report from device via interrupt endpoint
-TU_ATTR_WEAK void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance,
-                                             uint8_t const *report,
-                                             uint16_t len) {
-  (void)dev_addr;
-  (void)instance;
-  (void)report;
-  (void)len;
-}
-
 //--------------------------------------------------------------------+
 // USB Host using MAX3421E
 //--------------------------------------------------------------------+

--- a/src/arduino/Adafruit_USBH_Host.cpp
+++ b/src/arduino/Adafruit_USBH_Host.cpp
@@ -144,6 +144,17 @@ void Adafruit_USBH_Host::task(uint32_t timeout_ms, bool in_isr) {
   tuh_task_ext(timeout_ms, in_isr);
 }
 
+// Invoked when received report from device via interrupt endpoint
+TU_ATTR_WEAK void tuh_hid_report_received_cb(uint8_t dev_addr, uint8_t instance,
+                                             uint8_t const *report,
+                                             uint16_t len) {
+  (void)dev_addr;
+  (void)instance;
+  (void)report;
+  (void)len;
+}
+
+
 //--------------------------------------------------------------------+
 // USB Host using MAX3421E
 //--------------------------------------------------------------------+


### PR DESCRIPTION
Since https://github.com/hathach/tinyusb/pull/1968/changes#diff-20f1b796666c3650c5945d8e98660dd3abbfd40cb40aa6f47406be1ac4c84128R615 there is no need for these dummy impls anymore.

I don't get why GCC doesn't ignore them as they are marked as weak, but at least on arduino pico ignores custom impls.

