### PR TITLE
Respect user-defined CDC string descriptor

### DIFF
--- a/src/arduino/Adafruit_USBD_CDC.cpp
+++ b/src/arduino/Adafruit_USBD_CDC.cpp
@@ -102,7 +102,9 @@ void Adafruit_USBD_CDC::begin(uint32_t baud) {
   }
 
   _instance = _instance_count++;
-  this->setStringDescriptor("TinyUSB Serial");
+  if (_strid == 0) {
+    this->setStringDescriptor("TinyUSB Serial");
+  }
   TinyUSBDevice.addInterface(*this);
 }
 


### PR DESCRIPTION
This PR allows user sketches to set a custom string descriptor for the CDC-ACM interface.

## What changed

Previously, `Adafruit_USBD_CDC::begin()` always set the CDC interface string descriptor to `"TinyUSB Serial"`. This prevented user sketches from overriding the CDC interface string with `setStringDescriptor()`.

This patch changes the behavior to:

1. Check whether `_strid` has already been set by the user sketch.
2. If `_strid` is still `0`, use the default string descriptor `"TinyUSB Serial"`.
3. If the user sketch already called `setStringDescriptor()`, keep that user-defined string.

## Use case

On some boards supported by Adafruit TinyUSB, `Serial.begin()` may be called before `setup()`. In that case, a sketch can clear and rebuild the USB configuration with a custom CDC interface string:

```cpp
void setup() {
  // Clear all configurations including default Serial interface
  TinyUSBDevice.clearConfiguration();

  // Set custom string for CDC interface
  Serial.setStringDescriptor("My Special Serial Port");
  // For re-building descriptor
  TinyUSBDevice.addInterface(Serial);
  // The custom string descriptor is preserved.
  Serial.begin(115200);
}
```

This makes it possible for the custom CDC-ACM interface name to appear on the host instead of always using "TinyUSB Serial".