### PR TITLE
Add configurable CFG_TUD_ENDPOINT0_SIZE and CFG_TUD_HID_EP_BUFSIZE

### DIFF
--- a/src/arduino/ports/ch32/tusb_config_ch32.h
+++ b/src/arduino/ports/ch32/tusb_config_ch32.h
@@ -75,7 +75,9 @@ extern "C" {
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
 
+#ifndef CFG_TUD_ENDPOINT0_SIZE
 #define CFG_TUD_ENDPOINT0_SIZE 64
+#endif
 
 //------------- CLASS -------------//
 #ifndef CFG_TUD_CDC
@@ -117,7 +119,9 @@ extern "C" {
 #define CFG_TUD_MSC_EP_BUFSIZE 512
 
 // HID buffer size Should be sufficient to hold ID (if any) + Data
+#ifndef CFG_TUD_HID_EP_BUFSIZE
 #define CFG_TUD_HID_EP_BUFSIZE 64
+#endif
 
 // MIDI FIFO size of TX and RX
 #define CFG_TUD_MIDI_RX_BUFSIZE 128

--- a/src/arduino/ports/nrf/tusb_config_nrf.h
+++ b/src/arduino/ports/nrf/tusb_config_nrf.h
@@ -71,7 +71,9 @@ extern "C" {
 //--------------------------------------------------------------------
 
 #if CFG_TUD_ENABLED
+#ifndef CFG_TUD_ENDPOINT0_SIZE
 #define CFG_TUD_ENDPOINT0_SIZE 64
+#endif
 
 //------------- CLASS -------------//
 #ifndef CFG_TUD_CDC
@@ -107,7 +109,9 @@ extern "C" {
 #define CFG_TUD_MSC_EP_BUFSIZE 512
 
 // HID buffer size Should be sufficient to hold ID (if any) + Data
+#ifndef CFG_TUD_HID_EP_BUFSIZE
 #define CFG_TUD_HID_EP_BUFSIZE 64
+#endif
 
 // MIDI FIFO size of TX and RX
 #define CFG_TUD_MIDI_RX_BUFSIZE 128

--- a/src/arduino/ports/rp2040/tusb_config_rp2040.h
+++ b/src/arduino/ports/rp2040/tusb_config_rp2040.h
@@ -114,7 +114,9 @@ extern "C" {
 #define CFG_TUD_MSC_EP_BUFSIZE 512
 
 // HID buffer size Should be sufficient to hold ID (if any) + Data
+#ifndef CFG_TUD_HID_EP_BUFSIZE
 #define CFG_TUD_HID_EP_BUFSIZE 64
+#endif
 
 // MIDI FIFO size of TX and RX
 #define CFG_TUD_MIDI_RX_BUFSIZE 64

--- a/src/arduino/ports/samd/tusb_config_samd.h
+++ b/src/arduino/ports/samd/tusb_config_samd.h
@@ -64,7 +64,9 @@ extern "C" {
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------
 
+#ifndef CFG_TUD_ENDPOINT0_SIZE
 #define CFG_TUD_ENDPOINT0_SIZE 64
+#endif
 
 //------------- CLASS -------------//
 #ifndef CFG_TUD_CDC
@@ -100,7 +102,9 @@ extern "C" {
 #define CFG_TUD_MSC_EP_BUFSIZE 512
 
 // HID buffer size Should be sufficient to hold ID (if any) + Data
+#ifndef CFG_TUD_HID_EP_BUFSIZE
 #define CFG_TUD_HID_EP_BUFSIZE 64
+#endif
 
 // MIDI FIFO size of TX and RX
 #define CFG_TUD_MIDI_RX_BUFSIZE 128

--- a/src/arduino/ports/stm32/tusb_config_stm32.h
+++ b/src/arduino/ports/stm32/tusb_config_stm32.h
@@ -45,7 +45,9 @@
 //--------------------------------------------------------------------
 #define CFG_TUD_ENABLED 1
 #define CFG_TUD_MAX_SPEED OPT_MODE_FULL_SPEED // TODO some are highspeed
+#ifndef CFG_TUD_ENDPOINT0_SIZE
 #define CFG_TUD_ENDPOINT0_SIZE 64
+#endif
 
 // Classes
 #define CFG_TUD_CDC 1


### PR DESCRIPTION
Fixes #571 by adding ifdef guards which allows users to control/configure CFG_TUD_HID_EP_BUFSIZE and CFG_TUD_ENDPOINT0_SIZE. Otherwise, it defaults to the defaults set in the platform config headers.