### PR TITLE
Increase size of desc_str for USBD_Device

### DIFF
--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -319,7 +319,7 @@ uint16_t const *Adafruit_USBD_Device::descriptor_string_cb(uint8_t index,
       return NULL;
     }
 
-    chr_count = strcpy_utf16(_desc_str_arr[index], _desc_str + 1, 32);
+    chr_count = strcpy_utf16(_desc_str_arr[index], _desc_str + 1, 127);
     break;
   }
 

--- a/src/arduino/Adafruit_USBD_Device.cpp
+++ b/src/arduino/Adafruit_USBD_Device.cpp
@@ -319,7 +319,7 @@ uint16_t const *Adafruit_USBD_Device::descriptor_string_cb(uint8_t index,
       return NULL;
     }
 
-    chr_count = strcpy_utf16(_desc_str_arr[index], _desc_str + 1, 127);
+    chr_count = strcpy_utf16(_desc_str_arr[index], _desc_str + 1, 126);
     break;
   }
 

--- a/src/arduino/Adafruit_USBD_Device.h
+++ b/src/arduino/Adafruit_USBD_Device.h
@@ -56,7 +56,7 @@ private:
   // String descriptor
   const char *_desc_str_arr[STRING_DESCRIPTOR_MAX];
   uint8_t _desc_str_count;
-  uint16_t _desc_str[127 + 1]; // up to 127 unicode characters (254 bytes) with headers
+  uint16_t _desc_str[126 + 1]; // up to 126 unicode characters (252 bytes) with headers
 
 public:
   Adafruit_USBD_Device(void);

--- a/src/arduino/Adafruit_USBD_Device.h
+++ b/src/arduino/Adafruit_USBD_Device.h
@@ -56,7 +56,7 @@ private:
   // String descriptor
   const char *_desc_str_arr[STRING_DESCRIPTOR_MAX];
   uint8_t _desc_str_count;
-  uint16_t _desc_str[32 + 1]; // up to 32 unicode characters with headers
+  uint16_t _desc_str[127 + 1]; // up to 127 unicode characters (254 bytes) with headers
 
 public:
   Adafruit_USBD_Device(void);


### PR DESCRIPTION
The default size for desc_str was limited to 32 unicode characters which means longer string descriptors weren't possible. The max size for a descriptor in bytes is 255 bytes long since `bLength` is 1 byte long. So then subtract 2 from the size of `desc_str` to account for the header bytes.