### PR TITLE
Fix uninitialized value warnings in CDC

### DIFF
--- a/src/class/cdc/cdc_host.h
+++ b/src/class/cdc/cdc_host.h
@@ -151,7 +151,8 @@ bool tuh_cdc_set_control_line_state(uint8_t idx, uint16_t line_state, tuh_xfer_c
 // Request to Set DTR
 TU_ATTR_ALWAYS_INLINE static inline bool tuh_cdc_set_dtr(uint8_t idx, bool dtr_state, tuh_xfer_cb_t complete_cb,
                                                          uintptr_t user_data) {
-  cdc_line_control_state_t line_state = {.dtr = dtr_state};
+  cdc_line_control_state_t line_state = {};
+  line_state.dtr                      = dtr_state;
   line_state.rts                      = tuh_cdc_get_rts(idx);
   return tuh_cdc_set_control_line_state(idx, line_state.value, complete_cb, user_data);
 }
@@ -159,7 +160,8 @@ TU_ATTR_ALWAYS_INLINE static inline bool tuh_cdc_set_dtr(uint8_t idx, bool dtr_s
 // Request to Set RTS
 TU_ATTR_ALWAYS_INLINE static inline bool tuh_cdc_set_rts(uint8_t idx, bool rts_state, tuh_xfer_cb_t complete_cb,
                                                          uintptr_t user_data) {
-  cdc_line_control_state_t line_state = {.rts = rts_state};
+  cdc_line_control_state_t line_state = {};
+  line_state.rts                      = rts_state;
   line_state.dtr                      = tuh_cdc_get_dtr(idx);
   return tuh_cdc_set_control_line_state(idx, line_state.value, complete_cb, user_data);
 }


### PR DESCRIPTION
C++ doesn't prefill all values to 0 when only one value is specified in a struct initializer.  GCC with -Wall will warn about this if it sees it.

Replace the partial struct initialization with a C++ 0-init {} followed by a manual setting of the CDC RTS/DTR member.

Fixes the -Werror shown below with -Wall
````
/home/runner/arduino_ide/hardware/pico/rp2040/libraries/Adafruit_TinyUSB_Arduino/src/arduino/../class/cdc/cdc_host.h: In function 'bool tuh_cdc_set_dtr(uint8_t, bool, tuh_xfer_cb_t, uintptr_t)':
/home/runner/arduino_ide/hardware/pico/rp2040/libraries/Adafruit_TinyUSB_Arduino/src/arduino/../class/cdc/cdc_host.h:154:58: error: missing initializer for member 'cdc_line_control_state_t::<unnamed struct>::rts' [-Werror=missing-field-initializers]
  154 |   cdc_line_control_state_t line_state = {.dtr = dtr_state};
      |                                                          ^
/home/runner/arduino_ide/hardware/pico/rp2040/libraries/Adafruit_TinyUSB_Arduino/src/arduino/../class/cdc/cdc_host.h: In function 'bool tuh_cdc_set_rts(uint8_t, bool, tuh_xfer_cb_t, uintptr_t)':
/home/runner/arduino_ide/hardware/pico/rp2040/libraries/Adafruit_TinyUSB_Arduino/src/arduino/../class/cdc/cdc_host.h:162:58: error: missing initializer for member 'cdc_line_control_state_t::<unnamed struct>::dtr' [-Werror=missing-field-initializers]
  162 |   cdc_line_control_state_t line_state = {.rts = rts_state};
      |                                                          ^
cc1plus: all warnings being treated as errors
````
